### PR TITLE
[SAP] Allow to support_dynamic_secret_store_naming

### DIFF
--- a/barbican/plugin/util/multiple_backends.py
+++ b/barbican/plugin/util/multiple_backends.py
@@ -134,9 +134,14 @@ def sync_secret_stores(secretstore_manager, crypto_manager=None):
     def get_friendly_name_dict(ext_manager):
         """Returns dict of plugin internal name and friendly name entries."""
         names_dict = {}
+
         for ext in ext_manager.extensions:
             if ext.obj and hasattr(ext.obj, 'get_plugin_name'):
-                names_dict[ext.name] = ext.obj.get_plugin_name()
+                friendly_name = ext.obj.get_plugin_name()
+                # Always add the plugin's internal name to ensure uniqueness
+                unique_name = f"{friendly_name} [{ext.name}]"
+                names_dict[ext.name] = unique_name
+
         return names_dict
 
     ss_friendly_names = get_friendly_name_dict(secretstore_manager)

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,6 +67,8 @@ barbican.crypto.plugin =
     p11_crypto = barbican.plugin.crypto.p11_crypto:P11CryptoPlugin
     simple_crypto = barbican.plugin.crypto.simple_crypto:SimpleCryptoPlugin
     hsm_partition_crypto = barbican.plugin.crypto.hsm_partition_crypto:HSMPartitionCryptoPlugin
+    thales_hsm_crypto = barbican.plugin.crypto.hsm_partition_crypto:ThalesHSMPartitionCryptoPlugin
+    utimaco_hsm_crypto = barbican.plugin.crypto.hsm_partition_crypto:UtimacoHSMPartitionCryptoPlugin
 
 barbican.test.crypto.plugin =
     test_crypto = barbican.tests.crypto.test_plugin:TestCryptoPlugin

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,9 +67,7 @@ barbican.crypto.plugin =
     p11_crypto = barbican.plugin.crypto.p11_crypto:P11CryptoPlugin
     simple_crypto = barbican.plugin.crypto.simple_crypto:SimpleCryptoPlugin
     hsm_partition_crypto = barbican.plugin.crypto.hsm_partition_crypto:HSMPartitionCryptoPlugin
-    thales_hsm_crypto = barbican.plugin.crypto.hsm_partition_crypto:ThalesHSMPartitionCryptoPlugin
     utimaco_hsm_crypto = barbican.plugin.crypto.hsm_partition_crypto:UtimacoHSMPartitionCryptoPlugin
-
 barbican.test.crypto.plugin =
     test_crypto = barbican.tests.crypto.test_plugin:TestCryptoPlugin
 oslo.config.opts =


### PR DESCRIPTION
This patch should allow to implement the below 

```
[hsm_partition_crypto_plugin:utimaco_hsm]
plugin_name = Utimaco Partition Plugin
mkek_label = mkek_utimaco
...

[hsm_partition_crypto_plugin:thales_multi_hsm]
plugin_name = Thales Multi-Partition Plugin
mkek_label = mkek_thales
...

```
also fix :

`Problem saving entity for create: oslo_db.exception.DBDuplicateEntry: (pymysql.err.IntegrityError) (1062, "Duplicate entry 'HSM Partition Crypto Plugin' for key '_secret_stores_name_uc'")`
