### PR TITLE
Integration tests for secrets with SoftHSM simulating multi-tenancy

### DIFF
--- a/barbican/integrationtests/barbican.conf.test
+++ b/barbican/integrationtests/barbican.conf.test
@@ -1,0 +1,73 @@
+[DEFAULT]
+debug = True
+verbose = True
+wsgi_debug = True
+
+[database]
+connection = mysql+pymysql://rakib:12345@localhost:3306/barbican
+
+[paste_deploy]
+flavor = noauth
+
+[keystone_authtoken]
+enable = False
+
+[auth]
+enable_authentication = False
+
+[secretstore]
+enable_multiple_secret_stores = True
+stores_lookup_suffix = software, pkcs11, utimaco_hsm, thales_hsm
+
+[secretstore:software]
+name = Software Only Crypto
+secret_store_plugin = store_crypto
+crypto_plugin = simple_crypto
+
+[secretstore:pkcs11]
+name = PKCS11 HSM
+secret_store_plugin = store_crypto
+crypto_plugin = p11_crypto
+global_default = True
+
+[secretstore:utimaco_hsm]
+name = Utimaco HSM
+secret_store_plugin = store_crypto
+crypto_plugin = utimaco_hsm_crypto
+
+[secretstore:thales_hsm]
+name = Thales HSM
+secret_store_plugin = store_crypto
+crypto_plugin = thales_hsm_crypto
+
+[p11_crypto_plugin]
+library_path = /usr/local/lib/softhsm/libsofthsm2.so
+slot_id = 1338313258
+login = 12345
+hmac_key_length = 32
+mkek_label = mkek
+hmac_label = hmac
+hmac_key_type = CKK_GENERIC_SECRET
+hmac_keygen_mechanism = CKM_GENERIC_SECRET_KEY_GEN
+hmac_mechanism = CKM_SHA256_HMAC
+encryption_mechanism = CKM_AES_CBC
+
+[hsm_partition_crypto_plugin:utimaco_hsm]
+library_path = /usr/local/lib/softhsm/libsofthsm2.so
+hmac_key_length = 32
+mkek_label = mkek
+hmac_label = hmac
+hmac_key_type = CKK_GENERIC_SECRET
+hmac_keygen_mechanism = CKM_GENERIC_SECRET_KEY_GEN
+hmac_mechanism = CKM_SHA256_HMAC
+encryption_mechanism = CKM_AES_CBC
+
+[hsm_partition_crypto_plugin:thales_hsm]
+library_path = /usr/local/lib/softhsm/libsofthsm2.so
+hmac_key_length = 32
+mkek_label = mkek
+hmac_label = hmac
+hmac_key_type = CKK_GENERIC_SECRET
+hmac_keygen_mechanism = CKM_GENERIC_SECRET_KEY_GEN
+hmac_mechanism = CKM_SHA256_HMAC
+encryption_mechanism = CKM_AES_CBC

--- a/barbican/integrationtests/plugin/test_resource.py
+++ b/barbican/integrationtests/plugin/test_resource.py
@@ -1,0 +1,331 @@
+# Copyright (c) 2025 SAP SE
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import base64
+import json
+import subprocess
+import unittest
+from argparse import Namespace
+from enum import StrEnum
+
+from barbican.cmd.hsm_partition_create import create_hsm_partition
+from barbican.common import config, resources
+from barbican.model import models, repositories
+from barbican.model.models import States
+from barbican.plugin.crypto import hsm_partition_crypto, p11_crypto, pkcs11
+from barbican.plugin.resources import store_secret
+
+
+class HSMVendor(StrEnum):
+    THALES = "thales_hsm"
+    UTIMACO = "utimaco_hsm"
+
+
+class CryptoPlugin(StrEnum):
+    THALES = "thales_hsm_crypto"
+    UTIMACO = "utimaco_hsm_crypto"
+
+
+class HSMCryptoPlugin(StrEnum):
+    THALES = "barbican.plugin.crypto.hsm_partition_crypto.ThalesHSMPartitionCryptoPlugin"
+    UTIMACO = "barbican.plugin.crypto.hsm_partition_crypto.UtimacoHSMPartitionCryptoPlugin"
+
+
+hsm_vendor_to_plugin_mapping = {
+    HSMVendor.THALES: CryptoPlugin.THALES,
+    HSMVendor.UTIMACO: CryptoPlugin.UTIMACO,
+}
+
+
+class WhenTestingPluginResourceWithSoftHSM(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not cls.is_softhsm_available():
+            raise unittest.SkipTest("SoftHSM not found!")
+
+        # Load global configs
+        cls.conf = config.CONF
+        cls.conf.set_override(
+            "connection", "sqlite:///:memory:", group="database"
+        )
+        cls.conf.set_override("db_auto_create", True)
+
+        # Register crypto plugin vendors
+        p11_crypto.register_opts(cls.conf)
+        hsm_partition_crypto.register_opts_for_hsm_vendors(cls.conf)
+
+        # Generate mkek and hmac keys using `p11_crypto_plugin` configs
+        # ToDo: Note: `p11_crypto_plugin` configs are required
+        cls.pkcs11 = pkcs11.PKCS11(
+            library_path=cls.conf.p11_crypto_plugin.library_path,
+            login_passphrase=cls.conf.p11_crypto_plugin.login,
+            rw_session=cls.conf.p11_crypto_plugin.rw_session,
+            slot_id=int(cls.conf.p11_crypto_plugin.slot_id),
+            encryption_mechanism=cls.conf.p11_crypto_plugin.encryption_mechanism,
+            hmac_mechanism=cls.conf.p11_crypto_plugin.hmac_mechanism,
+            key_wrap_mechanism=cls.conf.p11_crypto_plugin.key_wrap_mechanism,
+            token_serial_number=cls.conf.p11_crypto_plugin.token_serial_number,
+            token_labels=cls.conf.p11_crypto_plugin.token_labels,
+        )
+        cls.gen_mkek()
+        cls.gen_hmac()
+
+        # Setup DB and tables with secret stores
+        # ToDo: Note: Initialization of secret stores are based on `p11_crypto_plugin` configs
+        repositories.setup_database_engine_and_factory(
+            initialize_secret_stores=True
+        )
+        repositories.start()
+
+        # Initialize repositories
+        cls.secret_stores_repo = repositories.get_secret_stores_repository()
+        cls.project_store_repo = (
+            repositories.get_project_secret_store_repository()
+        )
+        cls.hsm_partition_configs_repo = (
+            repositories.get_hsm_partition_config_repository()
+        )
+        cls.kek_data_repo = repositories.get_kek_datum_repository()
+        cls.secret_meta_repo = repositories.get_secret_meta_repository()
+        cls.encrypted_data_repo = repositories.get_encrypted_datum_repository()
+
+    @classmethod
+    def tearDownClass(cls):
+        # Delete mkek and hmac keys using `p11_crypto_plugin` configs
+        cls.delete_key(cls.conf.p11_crypto_plugin.mkek_label)
+        cls.delete_key(cls.conf.p11_crypto_plugin.hmac_label)
+
+    @classmethod
+    def is_softhsm_available(cls) -> bool:
+        try:
+            result = subprocess.run(
+                ["softhsm2-util", "--version"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            return result.returncode == 0
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            return False
+
+    @classmethod
+    def delete_key(cls, label: str):
+        try:
+            subprocess.run(
+                [
+                    "pkcs11-tool",
+                    "--module",
+                    cls.conf.p11_crypto_plugin.library_path,
+                    "--slot",
+                    str(cls.conf.p11_crypto_plugin.slot_id),
+                    "--pin",
+                    str(cls.conf.p11_crypto_plugin.login),
+                    "--delete-object",
+                    "--label",
+                    label,
+                    "--type",
+                    "secrkey",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            pass
+
+    @classmethod
+    def gen_mkek(cls):
+        session = cls.pkcs11.get_session()
+        label_exists = cls.does_label_exist(
+            "CKK_AES", cls.conf.p11_crypto_plugin.mkek_label, session
+        )
+        if label_exists:
+            return
+
+        cls.pkcs11.generate_key(
+            key_type="CKK_AES",
+            key_length=cls.conf.p11_crypto_plugin.mkek_length,
+            mechanism="CKM_AES_KEY_GEN",
+            session=session,
+            key_label=cls.conf.p11_crypto_plugin.mkek_label,
+            encrypt=True,
+            wrap=True,
+            master_key=True,
+        )
+        cls.pkcs11.return_session(session)
+
+    @classmethod
+    def gen_hmac(cls):
+        session = cls.pkcs11.get_session()
+        label_exists = cls.does_label_exist(
+            cls.conf.p11_crypto_plugin.hmac_key_type,
+            cls.conf.p11_crypto_plugin.hmac_label,
+            session,
+        )
+        if label_exists:
+            return
+
+        cls.pkcs11.generate_key(
+            key_type=cls.conf.p11_crypto_plugin.hmac_key_type,
+            key_length=32,
+            mechanism=cls.conf.p11_crypto_plugin.hmac_keygen_mechanism,
+            session=session,
+            key_label=cls.conf.p11_crypto_plugin.hmac_label,
+            sign=True,
+            master_key=True,
+        )
+        cls.pkcs11.return_session(session)
+
+    @classmethod
+    def does_label_exist(cls, key_type: str, label: str, session: int) -> bool:
+        key_handle = cls.pkcs11.get_key_handle(key_type, label, session)
+        if key_handle:
+            return True
+        return False
+
+    def _create_project_secret_store_mapping(
+            self, project_name: str, hsm_vendor: HSMVendor
+    ) -> models.Project:
+        # Create project in DB
+        # ToDo: Note: Project name must not contain (-) hyphens
+        project = resources.get_or_create_project(project_name)
+
+        # Create HSM partition config in DB
+        # ToDo: Refactor in a proper way with repository
+        # ToDo: Note: Some of the options are not present in HSM crypto plugin
+        args = Namespace(
+            external_project_id=project.external_id,
+            token_label="",
+            slot_id=self.conf.p11_crypto_plugin.slot_id,
+            library_path=self.conf.p11_crypto_plugin.library_path,
+            password=self.conf.p11_crypto_plugin.login,
+            partition_id=None,
+            partition_label="",
+        )
+        create_hsm_partition(args)
+
+        # Create project to secret store mapping in DB
+        vendor_plugin = hsm_vendor_to_plugin_mapping[hsm_vendor]
+        project_secret_store = None
+        secret_stores = self.secret_stores_repo.get_all()
+        for secret_store in secret_stores:
+            if secret_store.crypto_plugin == vendor_plugin:
+                project_secret_store = secret_store
+
+        if not project_secret_store:
+            raise unittest.SkipTest(
+                f"Secret store for plugin {vendor_plugin.value} not found!"
+            )
+
+        self.project_store_repo.create_or_update_for_project(
+            project.id, project_secret_store.id
+        )
+        return project
+
+    def test_secret_store_count_matches_config(self):
+        secret_stores = self.secret_stores_repo.get_all()
+
+        SECRET_STORE_PREFIX = "secretstore"
+        EXPECTED_SECTION_PARTS = 2
+
+        secret_store_config_count = 0
+        config_sections = self.conf.list_all_sections()
+        for section in config_sections:
+            if (
+                    section.startswith(SECRET_STORE_PREFIX)
+                    and len(section.split(":")) == EXPECTED_SECTION_PARTS
+            ):
+                secret_store_config_count += 1
+
+        self.assertEqual(
+            len(secret_stores),
+            secret_store_config_count,
+            f"Expected {secret_store_config_count} secret stores from config, "
+            f"but found {len(secret_stores)} in database",
+        )
+
+    def test_store_secret_creates_secret(self):
+        ALGORITHM = "AES"
+        BIT_LENGTH = 256
+        MODE = "CBC"
+        MECHANISM = "CKM_AES_CBC"
+        KEY_WRAP_MECHANISM = "CKM_AES_CBC_PAD"
+        SECRET_TYPE = "passphrase"
+        CONTENT_TYPE = "application/octet-stream"
+        CONTENT_ENCODING = "base64"
+        MKEK_LABEL = "mkek"
+        HMAC_LABEL = "hmac"
+        PROJECT_NAME = "testproject"
+
+        project = self._create_project_secret_store_mapping(
+            project_name=PROJECT_NAME, hsm_vendor=HSMVendor.UTIMACO
+        )
+
+        # Create a new secret
+        spec = {
+            "algorithm": ALGORITHM,
+            "bit_length": BIT_LENGTH,
+            "mode": MODE,
+            "secret_type": SECRET_TYPE,
+        }
+        new_secret, _ = store_secret(
+            unencrypted_raw=base64.b64encode(b"ABCDEFABCDEFABCDEFABCDEF"),
+            content_type_raw=CONTENT_TYPE,
+            content_encoding=CONTENT_ENCODING,
+            secret_model=models.Secret(spec),
+            project_model=project,
+        )
+
+        # Check secret values
+        self.assertEqual(new_secret.algorithm, ALGORITHM)
+        self.assertEqual(new_secret.bit_length, BIT_LENGTH)
+        self.assertEqual(new_secret.mode, MODE)
+        self.assertEqual(new_secret.secret_type, SECRET_TYPE)
+        self.assertEqual(new_secret.status, States.ACTIVE)
+
+        # Check encrypted data values
+        encrypted_data = new_secret.encrypted_data[0]
+        self.assertEqual(encrypted_data.content_type, CONTENT_TYPE)
+        self.assertIsNotNone(encrypted_data.cypher_text)
+        self.assertIsNotNone(encrypted_data.kek_meta_extended)
+        self.assertEqual(encrypted_data.status, States.ACTIVE)
+
+        kek_meta_extended = json.loads(encrypted_data.kek_meta_extended)
+        self.assertIsNotNone(kek_meta_extended["iv"])
+        self.assertEqual(kek_meta_extended["mechanism"], MECHANISM)
+
+        # Check kek data values
+        kek_data = encrypted_data.kek_meta_project
+        self.assertEqual(kek_data.algorithm, ALGORITHM)
+        self.assertEqual(kek_data.bit_length, BIT_LENGTH)
+        self.assertTrue(kek_data.kek_label.startswith(f"project-{PROJECT_NAME}-key-"))
+        self.assertEqual(kek_data.mode, MODE)
+        self.assertIsNotNone(kek_data.plugin_meta)
+        self.assertEqual(kek_data.plugin_name,HSMCryptoPlugin.UTIMACO.value)
+        self.assertEqual(kek_data.status, States.ACTIVE)
+
+        plugin_meta = json.loads(kek_data.plugin_meta)
+        self.assertIsNotNone(plugin_meta["iv"])
+        self.assertIsNotNone(plugin_meta["wrapped_key"])
+        self.assertIsNotNone(plugin_meta["hmac"])
+        self.assertEqual(plugin_meta["mkek_label"], MKEK_LABEL)
+        self.assertEqual(plugin_meta["hmac_label"], HMAC_LABEL)
+        self.assertEqual(plugin_meta["key_wrap_mechanism"], KEY_WRAP_MECHANISM)
+
+        # Check secret store metadata values
+        secret_store_metadata = new_secret.secret_store_metadata
+        self.assertEqual(secret_store_metadata["plugin_name"].value,
+                         "barbican.plugin.store_crypto.StoreCryptoAdapterPlugin")
+        self.assertEqual(secret_store_metadata["content_type"].value, CONTENT_TYPE)

--- a/barbican/integrationtests/plugin/test_resource.py
+++ b/barbican/integrationtests/plugin/test_resource.py
@@ -21,11 +21,11 @@ from argparse import Namespace
 from enum import StrEnum
 
 from barbican.cmd.hsm_partition_create import create_hsm_partition
-from barbican.common import config, resources
+from barbican.common import config, exception, resources
 from barbican.model import models, repositories
 from barbican.model.models import States
 from barbican.plugin.crypto import hsm_partition_crypto, p11_crypto, pkcs11
-from barbican.plugin.resources import store_secret
+from barbican.plugin.resources import delete_secret, get_secret, store_secret
 
 
 class HSMVendor(StrEnum):
@@ -94,12 +94,7 @@ class WhenTestingPluginResourceWithSoftHSM(unittest.TestCase):
         cls.project_store_repo = (
             repositories.get_project_secret_store_repository()
         )
-        cls.hsm_partition_configs_repo = (
-            repositories.get_hsm_partition_config_repository()
-        )
-        cls.kek_data_repo = repositories.get_kek_datum_repository()
-        cls.secret_meta_repo = repositories.get_secret_meta_repository()
-        cls.encrypted_data_repo = repositories.get_encrypted_datum_repository()
+        cls.secret_repo = repositories.get_secret_repository()
 
     @classmethod
     def tearDownClass(cls):
@@ -196,7 +191,7 @@ class WhenTestingPluginResourceWithSoftHSM(unittest.TestCase):
         return False
 
     def _create_project_secret_store_mapping(
-            self, project_name: str, hsm_vendor: HSMVendor
+        self, project_name: str, hsm_vendor: HSMVendor
     ) -> models.Project:
         # Create project in DB
         # ToDo: Note: Project name must not contain (-) hyphens
@@ -244,8 +239,8 @@ class WhenTestingPluginResourceWithSoftHSM(unittest.TestCase):
         config_sections = self.conf.list_all_sections()
         for section in config_sections:
             if (
-                    section.startswith(SECRET_STORE_PREFIX)
-                    and len(section.split(":")) == EXPECTED_SECTION_PARTS
+                section.startswith(SECRET_STORE_PREFIX)
+                and len(section.split(":")) == EXPECTED_SECTION_PARTS
             ):
                 secret_store_config_count += 1
 
@@ -310,10 +305,12 @@ class WhenTestingPluginResourceWithSoftHSM(unittest.TestCase):
         kek_data = encrypted_data.kek_meta_project
         self.assertEqual(kek_data.algorithm, ALGORITHM)
         self.assertEqual(kek_data.bit_length, BIT_LENGTH)
-        self.assertTrue(kek_data.kek_label.startswith(f"project-{PROJECT_NAME}-key-"))
+        self.assertTrue(
+            kek_data.kek_label.startswith(f"project-{PROJECT_NAME}-key-")
+        )
         self.assertEqual(kek_data.mode, MODE)
         self.assertIsNotNone(kek_data.plugin_meta)
-        self.assertEqual(kek_data.plugin_name,HSMCryptoPlugin.UTIMACO.value)
+        self.assertEqual(kek_data.plugin_name, HSMCryptoPlugin.UTIMACO.value)
         self.assertEqual(kek_data.status, States.ACTIVE)
 
         plugin_meta = json.loads(kek_data.plugin_meta)
@@ -326,6 +323,86 @@ class WhenTestingPluginResourceWithSoftHSM(unittest.TestCase):
 
         # Check secret store metadata values
         secret_store_metadata = new_secret.secret_store_metadata
-        self.assertEqual(secret_store_metadata["plugin_name"].value,
-                         "barbican.plugin.store_crypto.StoreCryptoAdapterPlugin")
-        self.assertEqual(secret_store_metadata["content_type"].value, CONTENT_TYPE)
+        self.assertEqual(
+            secret_store_metadata["plugin_name"].value,
+            "barbican.plugin.store_crypto.StoreCryptoAdapterPlugin",
+        )
+        self.assertEqual(
+            secret_store_metadata["content_type"].value, CONTENT_TYPE
+        )
+
+    def test_get_secret_returns_secret(self):
+        ALGORITHM = "AES"
+        BIT_LENGTH = 256
+        MODE = "CBC"
+        SECRET_TYPE = "passphrase"
+        CONTENT_TYPE = "application/octet-stream"
+        CONTENT_ENCODING = "base64"
+        PROJECT_NAME = "testproject2"
+
+        project = self._create_project_secret_store_mapping(
+            project_name=PROJECT_NAME, hsm_vendor=HSMVendor.UTIMACO
+        )
+
+        # Create a new secret
+        raw_secret = b"ABCDEFABCDEFABCDEFABCDEF"
+        spec = {
+            "algorithm": ALGORITHM,
+            "bit_length": BIT_LENGTH,
+            "mode": MODE,
+            "secret_type": SECRET_TYPE,
+        }
+        new_secret, _ = store_secret(
+            unencrypted_raw=base64.b64encode(raw_secret),
+            content_type_raw=CONTENT_TYPE,
+            content_encoding=CONTENT_ENCODING,
+            secret_model=models.Secret(spec),
+            project_model=project,
+        )
+
+        # Get the newly created secret
+        retrieved_raw_secret = get_secret(
+            requesting_content_type=CONTENT_TYPE,
+            secret_model=new_secret,
+            project_model=project,
+        )
+        self.assertEqual(raw_secret, retrieved_raw_secret)
+
+    def test_delete_secret_deletes_secret(self):
+        ALGORITHM = "AES"
+        BIT_LENGTH = 256
+        MODE = "CBC"
+        SECRET_TYPE = "passphrase"
+        CONTENT_TYPE = "application/octet-stream"
+        CONTENT_ENCODING = "base64"
+        PROJECT_NAME = "testproject3"
+
+        project = self._create_project_secret_store_mapping(
+            project_name=PROJECT_NAME, hsm_vendor=HSMVendor.UTIMACO
+        )
+
+        # Create a new secret
+        raw_secret = b"ABCDEFABCDEFABCDEFABCDEF"
+        spec = {
+            "algorithm": ALGORITHM,
+            "bit_length": BIT_LENGTH,
+            "mode": MODE,
+            "secret_type": SECRET_TYPE,
+        }
+        new_secret, _ = store_secret(
+            unencrypted_raw=base64.b64encode(raw_secret),
+            content_type_raw=CONTENT_TYPE,
+            content_encoding=CONTENT_ENCODING,
+            secret_model=models.Secret(spec),
+            project_model=project,
+        )
+
+        # Delete the newly created secret
+        delete_secret(secret_model=new_secret, project_id=project.external_id)
+
+        # Verify that the secret is not present
+        self.assertRaises(
+            exception.NotFound,
+            self.secret_repo.get_secret_by_id,
+            new_secret.id,
+        )

--- a/barbican/integrationtests/plugin/test_resource_softhsm.py
+++ b/barbican/integrationtests/plugin/test_resource_softhsm.py
@@ -495,12 +495,3 @@ class TestPluginResourceWithSoftHSM:
                 secret_model=models.Secret(spec),
                 project_id=project.external_id,
             )
-
-
-# ToDo:
-# - Add library path in options <<
-# - Update configs <<
-# - Create configs for test <<
-# - Update the partition conf table
-# - Create repository class and refactor the CLI
-# -

--- a/barbican/integrationtests/plugin/test_resource_softhsm.py
+++ b/barbican/integrationtests/plugin/test_resource_softhsm.py
@@ -13,19 +13,29 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from argparse import Namespace
 import base64
+from enum import StrEnum
 import json
 import subprocess
 import unittest
-from argparse import Namespace
-from enum import StrEnum
+
+import pytest
 
 from barbican.cmd.hsm_partition_create import create_hsm_partition
-from barbican.common import config, exception, resources
-from barbican.model import models, repositories
-from barbican.model.models import States
-from barbican.plugin.crypto import hsm_partition_crypto, p11_crypto, pkcs11
-from barbican.plugin.resources import delete_secret, get_secret, store_secret
+from barbican.common import config
+from barbican.common import exception
+from barbican.common import resources
+from barbican.common.utils import is_multiple_backends_enabled
+from barbican.model import models
+from barbican.model import repositories
+from barbican.plugin.crypto import hsm_partition_crypto
+from barbican.plugin.crypto import p11_crypto
+from barbican.plugin.crypto import pkcs11
+from barbican.plugin.interface.secret_store import StorePluginNotAvailableOrMisconfigured  # noqa: E501
+from barbican.plugin.resources import delete_secret
+from barbican.plugin.resources import get_secret
+from barbican.plugin.resources import store_secret
 
 
 class HSMVendor(StrEnum):
@@ -39,8 +49,8 @@ class CryptoPlugin(StrEnum):
 
 
 class HSMCryptoPlugin(StrEnum):
-    THALES = "barbican.plugin.crypto.hsm_partition_crypto.ThalesHSMPartitionCryptoPlugin"
-    UTIMACO = "barbican.plugin.crypto.hsm_partition_crypto.UtimacoHSMPartitionCryptoPlugin"
+    THALES = "barbican.plugin.crypto.hsm_partition_crypto.ThalesHSMPartitionCryptoPlugin"  # noqa: E501
+    UTIMACO = "barbican.plugin.crypto.hsm_partition_crypto.UtimacoHSMPartitionCryptoPlugin"  # noqa: E501
 
 
 hsm_vendor_to_plugin_mapping = {
@@ -48,10 +58,15 @@ hsm_vendor_to_plugin_mapping = {
     HSMVendor.UTIMACO: CryptoPlugin.UTIMACO,
 }
 
+hsm_vendor_to_hsm_plugin_mapping = {
+    HSMVendor.THALES: HSMCryptoPlugin.THALES,
+    HSMVendor.UTIMACO: HSMCryptoPlugin.UTIMACO,
+}
 
-class WhenTestingPluginResourceWithSoftHSM(unittest.TestCase):
+
+class TestPluginResourceWithSoftHSM:
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         if not cls.is_softhsm_available():
             raise unittest.SkipTest("SoftHSM not found!")
 
@@ -73,7 +88,7 @@ class WhenTestingPluginResourceWithSoftHSM(unittest.TestCase):
             login_passphrase=cls.conf.p11_crypto_plugin.login,
             rw_session=cls.conf.p11_crypto_plugin.rw_session,
             slot_id=int(cls.conf.p11_crypto_plugin.slot_id),
-            encryption_mechanism=cls.conf.p11_crypto_plugin.encryption_mechanism,
+            encryption_mechanism=cls.conf.p11_crypto_plugin.encryption_mechanism,  # noqa: E501
             hmac_mechanism=cls.conf.p11_crypto_plugin.hmac_mechanism,
             key_wrap_mechanism=cls.conf.p11_crypto_plugin.key_wrap_mechanism,
             token_serial_number=cls.conf.p11_crypto_plugin.token_serial_number,
@@ -83,7 +98,7 @@ class WhenTestingPluginResourceWithSoftHSM(unittest.TestCase):
         cls.gen_hmac()
 
         # Setup DB and tables with secret stores
-        # ToDo: Note: Initialization of secret stores are based on `p11_crypto_plugin` configs
+        # ToDo: Note: Init of secret stores is based on `p11_crypto_plugin` configs  # noqa: E501
         repositories.setup_database_engine_and_factory(
             initialize_secret_stores=True
         )
@@ -97,7 +112,7 @@ class WhenTestingPluginResourceWithSoftHSM(unittest.TestCase):
         cls.secret_repo = repositories.get_secret_repository()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         # Delete mkek and hmac keys using `p11_crypto_plugin` configs
         cls.delete_key(cls.conf.p11_crypto_plugin.mkek_label)
         cls.delete_key(cls.conf.p11_crypto_plugin.hmac_label)
@@ -230,6 +245,15 @@ class WhenTestingPluginResourceWithSoftHSM(unittest.TestCase):
         return project
 
     def test_secret_store_count_matches_config(self):
+        """Secret stores count from the DB matches with the conf if multiple
+
+        secret stores option is enabled
+        """
+        if not is_multiple_backends_enabled():
+            raise unittest.SkipTest(
+                "Multiple secret stores option is not enabled!"
+            )
+
         secret_stores = self.secret_stores_repo.get_all()
 
         SECRET_STORE_PREFIX = "secretstore"
@@ -244,14 +268,20 @@ class WhenTestingPluginResourceWithSoftHSM(unittest.TestCase):
             ):
                 secret_store_config_count += 1
 
-        self.assertEqual(
-            len(secret_stores),
-            secret_store_config_count,
-            f"Expected {secret_store_config_count} secret stores from config, "
-            f"but found {len(secret_stores)} in database",
+        assert len(secret_stores) == secret_store_config_count, (
+            f"Expected {secret_store_config_count} secret stores from "
+            f"config, but found {len(secret_stores)} in database"
         )
 
-    def test_store_secret_creates_secret(self):
+    @pytest.mark.parametrize(
+        "project_name, hsm_vendor",
+        [
+            ("testproject_utimaco", HSMVendor.UTIMACO),
+            ("testproject_thales", HSMVendor.THALES),
+        ],
+    )
+    def test_store_secret_creates_secret(self, project_name, hsm_vendor):
+        """Creates a new secret"""
         ALGORITHM = "AES"
         BIT_LENGTH = 256
         MODE = "CBC"
@@ -262,10 +292,10 @@ class WhenTestingPluginResourceWithSoftHSM(unittest.TestCase):
         CONTENT_ENCODING = "base64"
         MKEK_LABEL = "mkek"
         HMAC_LABEL = "hmac"
-        PROJECT_NAME = "testproject"
+        PROJECT_NAME = project_name
 
         project = self._create_project_secret_store_mapping(
-            project_name=PROJECT_NAME, hsm_vendor=HSMVendor.UTIMACO
+            project_name=PROJECT_NAME, hsm_vendor=hsm_vendor
         )
 
         # Create a new secret
@@ -284,61 +314,64 @@ class WhenTestingPluginResourceWithSoftHSM(unittest.TestCase):
         )
 
         # Check secret values
-        self.assertEqual(new_secret.algorithm, ALGORITHM)
-        self.assertEqual(new_secret.bit_length, BIT_LENGTH)
-        self.assertEqual(new_secret.mode, MODE)
-        self.assertEqual(new_secret.secret_type, SECRET_TYPE)
-        self.assertEqual(new_secret.status, States.ACTIVE)
+        assert new_secret.algorithm == ALGORITHM
+        assert new_secret.bit_length == BIT_LENGTH
+        assert new_secret.mode == MODE
+        assert new_secret.secret_type == SECRET_TYPE
+        assert new_secret.status == models.States.ACTIVE
 
         # Check encrypted data values
         encrypted_data = new_secret.encrypted_data[0]
-        self.assertEqual(encrypted_data.content_type, CONTENT_TYPE)
-        self.assertIsNotNone(encrypted_data.cypher_text)
-        self.assertIsNotNone(encrypted_data.kek_meta_extended)
-        self.assertEqual(encrypted_data.status, States.ACTIVE)
+        assert encrypted_data.content_type == CONTENT_TYPE
+        assert encrypted_data.cypher_text is not None
+        assert encrypted_data.kek_meta_extended is not None
+        assert encrypted_data.status == models.States.ACTIVE
 
         kek_meta_extended = json.loads(encrypted_data.kek_meta_extended)
-        self.assertIsNotNone(kek_meta_extended["iv"])
-        self.assertEqual(kek_meta_extended["mechanism"], MECHANISM)
+        assert kek_meta_extended["iv"] is not None
+        assert kek_meta_extended["mechanism"] == MECHANISM
 
         # Check kek data values
         kek_data = encrypted_data.kek_meta_project
-        self.assertEqual(kek_data.algorithm, ALGORITHM)
-        self.assertEqual(kek_data.bit_length, BIT_LENGTH)
-        self.assertTrue(
+        assert kek_data.algorithm == ALGORITHM
+        assert kek_data.bit_length == BIT_LENGTH
+        assert (
             kek_data.kek_label.startswith(f"project-{PROJECT_NAME}-key-")
+            is True
         )
-        self.assertEqual(kek_data.mode, MODE)
-        self.assertIsNotNone(kek_data.plugin_meta)
-        self.assertEqual(kek_data.plugin_name, HSMCryptoPlugin.UTIMACO.value)
-        self.assertEqual(kek_data.status, States.ACTIVE)
+        assert kek_data.mode == MODE
+        assert kek_data.plugin_meta is not None
+        assert (
+            kek_data.plugin_name
+            == hsm_vendor_to_hsm_plugin_mapping[hsm_vendor]
+        )
+        assert kek_data.status == models.States.ACTIVE
 
         plugin_meta = json.loads(kek_data.plugin_meta)
-        self.assertIsNotNone(plugin_meta["iv"])
-        self.assertIsNotNone(plugin_meta["wrapped_key"])
-        self.assertIsNotNone(plugin_meta["hmac"])
-        self.assertEqual(plugin_meta["mkek_label"], MKEK_LABEL)
-        self.assertEqual(plugin_meta["hmac_label"], HMAC_LABEL)
-        self.assertEqual(plugin_meta["key_wrap_mechanism"], KEY_WRAP_MECHANISM)
+        assert plugin_meta["iv"] is not None
+        assert plugin_meta["wrapped_key"] is not None
+        assert plugin_meta["hmac"] is not None
+        assert plugin_meta["mkek_label"] == MKEK_LABEL
+        assert plugin_meta["hmac_label"] == HMAC_LABEL
+        assert plugin_meta["key_wrap_mechanism"] == KEY_WRAP_MECHANISM
 
         # Check secret store metadata values
         secret_store_metadata = new_secret.secret_store_metadata
-        self.assertEqual(
-            secret_store_metadata["plugin_name"].value,
-            "barbican.plugin.store_crypto.StoreCryptoAdapterPlugin",
+        assert (
+            secret_store_metadata["plugin_name"].value
+            == "barbican.plugin.store_crypto.StoreCryptoAdapterPlugin"
         )
-        self.assertEqual(
-            secret_store_metadata["content_type"].value, CONTENT_TYPE
-        )
+        assert secret_store_metadata["content_type"].value == CONTENT_TYPE
 
     def test_get_secret_returns_secret(self):
+        """Retrieves the raw secret if present"""
         ALGORITHM = "AES"
         BIT_LENGTH = 256
         MODE = "CBC"
         SECRET_TYPE = "passphrase"
         CONTENT_TYPE = "application/octet-stream"
         CONTENT_ENCODING = "base64"
-        PROJECT_NAME = "testproject2"
+        PROJECT_NAME = "testproject"
 
         project = self._create_project_secret_store_mapping(
             project_name=PROJECT_NAME, hsm_vendor=HSMVendor.UTIMACO
@@ -360,15 +393,43 @@ class WhenTestingPluginResourceWithSoftHSM(unittest.TestCase):
             project_model=project,
         )
 
-        # Get the newly created secret
+        # Retrieve the newly created secret
         retrieved_raw_secret = get_secret(
             requesting_content_type=CONTENT_TYPE,
             secret_model=new_secret,
             project_model=project,
         )
-        self.assertEqual(raw_secret, retrieved_raw_secret)
+        assert raw_secret == retrieved_raw_secret
+
+    def test_get_secret_raises_exception(self):
+        """Raises exception if the secret is not present"""
+        ALGORITHM = "AES"
+        BIT_LENGTH = 256
+        MODE = "CBC"
+        SECRET_TYPE = "passphrase"
+        CONTENT_TYPE = "application/octet-stream"
+        PROJECT_NAME = "testproject2"
+
+        project = self._create_project_secret_store_mapping(
+            project_name=PROJECT_NAME, hsm_vendor=HSMVendor.UTIMACO
+        )
+
+        # Retrieve a secret which is not present
+        spec = {
+            "algorithm": ALGORITHM,
+            "bit_length": BIT_LENGTH,
+            "mode": MODE,
+            "secret_type": SECRET_TYPE,
+        }
+        with pytest.raises(StorePluginNotAvailableOrMisconfigured):
+            get_secret(
+                requesting_content_type=CONTENT_TYPE,
+                secret_model=models.Secret(spec),
+                project_model=project,
+            )
 
     def test_delete_secret_deletes_secret(self):
+        """Deletes secret if present"""
         ALGORITHM = "AES"
         BIT_LENGTH = 256
         MODE = "CBC"
@@ -401,8 +462,30 @@ class WhenTestingPluginResourceWithSoftHSM(unittest.TestCase):
         delete_secret(secret_model=new_secret, project_id=project.external_id)
 
         # Verify that the secret is not present
-        self.assertRaises(
-            exception.NotFound,
-            self.secret_repo.get_secret_by_id,
-            new_secret.id,
+        with pytest.raises(exception.NotFound):
+            self.secret_repo.get_secret_by_id(new_secret.id)
+
+    def test_delete_secret_raises_exception(self):
+        """Raises exception if the secret is not present"""
+        ALGORITHM = "AES"
+        BIT_LENGTH = 256
+        MODE = "CBC"
+        SECRET_TYPE = "passphrase"
+        PROJECT_NAME = "testproject4"
+
+        project = self._create_project_secret_store_mapping(
+            project_name=PROJECT_NAME, hsm_vendor=HSMVendor.UTIMACO
         )
+
+        # Delete a secret which is not present
+        spec = {
+            "algorithm": ALGORITHM,
+            "bit_length": BIT_LENGTH,
+            "mode": MODE,
+            "secret_type": SECRET_TYPE,
+        }
+        with pytest.raises(exception.NotFound):
+            delete_secret(
+                secret_model=models.Secret(spec),
+                project_id=project.external_id,
+            )

--- a/barbican/integrationtests/plugin/test_resource_softhsm.py
+++ b/barbican/integrationtests/plugin/test_resource_softhsm.py
@@ -17,6 +17,7 @@ from argparse import Namespace
 import base64
 from enum import StrEnum
 import json
+from pathlib import Path
 import subprocess
 import unittest
 
@@ -70,8 +71,13 @@ class TestPluginResourceWithSoftHSM:
         if not cls.is_softhsm_available():
             raise unittest.SkipTest("SoftHSM not found!")
 
-        # Load global configs
+        # Load test configs
+        test_config_file = (
+            Path(__file__).parent.parent.resolve() / "barbican.conf.test"
+        )
+        config.parse_args(config.CONF, default_config_files=[test_config_file])
         cls.conf = config.CONF
+
         cls.conf.set_override(
             "connection", "sqlite:///:memory:", group="database"
         )
@@ -489,3 +495,12 @@ class TestPluginResourceWithSoftHSM:
                 secret_model=models.Secret(spec),
                 project_id=project.external_id,
             )
+
+
+# ToDo:
+# - Add library path in options <<
+# - Update configs <<
+# - Create configs for test <<
+# - Update the partition conf table
+# - Create repository class and refactor the CLI
+# -

--- a/barbican/plugin/crypto/hsm_partition_crypto.py
+++ b/barbican/plugin/crypto/hsm_partition_crypto.py
@@ -32,6 +32,10 @@ hsm_partition_crypto_plugin_group = cfg.OptGroup(
 )
 hsm_partition_crypto_plugin_opts = [
     cfg.StrOpt(
+        "library_path",
+        help=u._("Path to vendor library"),
+    ),
+    cfg.StrOpt(
         "plugin_name",
         help=u._("User friendly plugin name"),
         default="HSM Partition Crypto Plugin",
@@ -229,7 +233,7 @@ class HSMPartitionCryptoPlugin(p11_crypto.P11CryptoPlugin):
             self.conf = conf[self.section_name]
 
         # Initialize basic attributes from config
-        self.library_path = None
+        self.library_path = self.conf.library_path
         self.login = None
         self.rw_session = self.conf.rw_session
         self.slot_id = None
@@ -317,7 +321,6 @@ class HSMPartitionCryptoPlugin(p11_crypto.P11CryptoPlugin):
         self.current_partition = partition
 
         # Set required attributes for parent class
-        self.library_path = partition.credentials["library_path"]
         self.login = partition.credentials["password"]
         self.slot_id = int(partition.slot_id)
         self.token_labels = (

--- a/barbican/plugin/crypto/hsm_partition_crypto.py
+++ b/barbican/plugin/crypto/hsm_partition_crypto.py
@@ -135,7 +135,7 @@ hsm_partition_crypto_plugin_opts = [
 
 
 # Register Vendor-specific sections
-def register_hsm_vendor_sections():
+def register_opts_for_hsm_vendors(conf):
     # Define vendor HSMs that you want to support
     vendors = ["thales_hsm", "utimaco_hsm"]
 
@@ -150,8 +150,8 @@ def register_hsm_vendor_sections():
         )
 
         # Register the group and options
-        CONF.register_group(vendor_group)
-        CONF.register_opts(
+        conf.register_group(vendor_group)
+        conf.register_opts(
             hsm_partition_crypto_plugin_opts, group=vendor_group
         )
 
@@ -161,7 +161,7 @@ def register_hsm_vendor_sections():
 
 
 # Register all vendor sections
-register_hsm_vendor_sections()
+register_opts_for_hsm_vendors(CONF)
 
 CONF.register_group(hsm_partition_crypto_plugin_group)
 CONF.register_opts(
@@ -378,7 +378,6 @@ class HSMPartitionCryptoPlugin(p11_crypto.P11CryptoPlugin):
 
 
 class UtimacoHSMPartitionCryptoPlugin(HSMPartitionCryptoPlugin):
-
     """Utimaco HSM Partition Crypto Plugin.
 
     This is a specialized version of HSMPartitionCryptoPlugin configured
@@ -393,7 +392,6 @@ class UtimacoHSMPartitionCryptoPlugin(HSMPartitionCryptoPlugin):
 
 
 class ThalesHSMPartitionCryptoPlugin(HSMPartitionCryptoPlugin):
-
     """Thales HSM Partition Crypto Plugin.
 
     This is a specialized version of HSMPartitionCryptoPlugin configured

--- a/barbican/tests/plugin/crypto/test_hsm_partition_crypto.py
+++ b/barbican/tests/plugin/crypto/test_hsm_partition_crypto.py
@@ -85,6 +85,7 @@ class WhenTestingHSMPartitionCryptoPlugin(utils.BaseTestCase):
         self.conf.hsm_partition_crypto_plugin.default_partition_id = (
             self.partition_id
         )
+        self.conf.hsm_partition_crypto_plugin.library_path = self.library_path
 
     def test_init_with_global_conf(self):
         store_plugin_name = "default"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -155,8 +155,6 @@ encryption_mechanism = CKM_AES_CBC
 
 [hsm_partition_crypto_plugin:utimaco_hsm]
 library_path = /usr/local/lib/softhsm/libsofthsm2.so
-slot_id = <slot_id>
-login = <crypto_user_pin>
 hmac_key_length = 32
 mkek_label = mkek
 hmac_label = hmac
@@ -167,8 +165,6 @@ encryption_mechanism = CKM_AES_CBC
 
 [hsm_partition_crypto_plugin:thales_hsm]
 library_path = /usr/local/lib/softhsm/libsofthsm2.so
-slot_id = <slot_id>
-login = <crypto_user_pin>
 hmac_key_length = 32
 mkek_label = mkek
 hmac_label = hmac

--- a/getting-started.md
+++ b/getting-started.md
@@ -1,0 +1,332 @@
+# Local Setup Guide
+
+This step-by-step guide provides instruction about running Barbican with SoftHSM integration simulating multi-tenancy with Thales and 
+Utimaco HSMs for local development.
+
+## Install SoftHSMv2
+```
+git clone git@github.com:softhsm/SoftHSMv2.git
+cd SoftHSMv2
+brew install automake libtool pkg-config cppunit openssl
+./autogen.sh
+./configure --with-openssl=$(brew --prefix openssl)
+make
+sudo make install
+```
+
+Credits to [microshine](https://github.com/parallaxsecond/rust-cryptoki/issues/191#issuecomment-2590877745).
+
+## Install pkcs11-tool
+
+```
+brew install opensc
+```
+
+Follow: https://docs.nitrokey.com/nethsm/pkcs11-tool
+
+
+## Initialize a Token
+
+Initialize the token at a free slot by setting crypto user & security officer PINs:
+
+```
+softhsm2-util --init-token --free --label <label>
+```
+
+Display all available slots:
+
+```
+softhsm2-util --show-slots
+```
+
+List tokens with slots:
+
+```
+pkcs11-tool --module /usr/local/lib/softhsm/libsofthsm2.so -T
+```
+
+## Clone Barbican
+
+Clone the project:
+
+```
+git clone git@github.com:sapcc/barbican.git
+```
+
+Follow [this guideline](https://docs.openstack.org/barbican/latest/contributor/dev.html) to set up Barbican for local 
+development.
+
+## Run MariaDB
+
+Create a Docker compose file `barbican.yaml` anywhere:
+
+```
+version: "3.8"
+
+services:
+  mariadb:
+    image: mariadb:latest
+    container_name: barbican_db
+    environment:
+      MYSQL_ROOT_PASSWORD: <db_root_password>
+      MYSQL_DATABASE: <db_bame>
+      MARIADB_USER: <db_user>
+      MARIADB_PASSWORD: <db_password>
+    ports:
+      - "3306:3306"
+    networks:
+      - barbican_db_network
+    volumes:
+      - mariadb_data:/var/lib/mysql
+
+networks:
+  barbican_db_network:
+    driver: bridge
+
+volumes:
+  mariadb_data:
+    
+```
+
+Run the Docker compose file:
+
+```
+docker-compose -f barbican.yml up -d
+```
+
+## Update Barbican Config
+
+Update the `barbican/etc/barbican/barbican.conf` with the following configurations:
+
+```
+[DEFAULT]
+debug = True
+verbose = True
+wsgi_debug = True
+
+[database]
+connection = mysql+pymysql://<db_user>:<db_password>@localhost:3306/<db_name>
+
+[paste_deploy]
+flavor = noauth
+
+[keystone_authtoken]
+enable = False
+
+[auth]
+enable_authentication = False
+
+[secretstore]
+enable_multiple_secret_stores = True
+stores_lookup_suffix = software, pkcs11, utimaco_hsm, thales_hsm
+
+[secretstore:software]
+name = Software Only Crypto
+secret_store_plugin = store_crypto
+crypto_plugin = simple_crypto
+
+[secretstore:pkcs11]
+name = PKCS11 HSM
+secret_store_plugin = store_crypto
+crypto_plugin = p11_crypto
+global_default = True
+
+[secretstore:utimaco_hsm]
+name = Utimaco HSM
+secret_store_plugin = store_crypto
+crypto_plugin = utimaco_hsm_crypto
+
+[secretstore:thales_hsm]
+name = Thales HSM
+secret_store_plugin = store_crypto
+crypto_plugin = thales_hsm_crypto
+
+[p11_crypto_plugin]
+library_path = /usr/local/lib/softhsm/libsofthsm2.so
+slot_id = <slot_id>
+login = <crypto_user_pin>
+hmac_key_length = 32
+mkek_label = mkek
+hmac_label = hmac
+hmac_key_type = CKK_GENERIC_SECRET
+hmac_keygen_mechanism = CKM_GENERIC_SECRET_KEY_GEN
+hmac_mechanism = CKM_SHA256_HMAC
+encryption_mechanism = CKM_AES_CBC
+
+[hsm_partition_crypto_plugin:utimaco_hsm]
+library_path = /usr/local/lib/softhsm/libsofthsm2.so
+slot_id = <slot_id>
+login = <crypto_user_pin>
+hmac_key_length = 32
+mkek_label = mkek
+hmac_label = hmac
+hmac_key_type = CKK_GENERIC_SECRET
+hmac_keygen_mechanism = CKM_GENERIC_SECRET_KEY_GEN
+hmac_mechanism = CKM_SHA256_HMAC
+encryption_mechanism = CKM_AES_CBC
+
+[hsm_partition_crypto_plugin:thales_hsm]
+library_path = /usr/local/lib/softhsm/libsofthsm2.so
+slot_id = <slot_id>
+login = <crypto_user_pin>
+hmac_key_length = 32
+mkek_label = mkek
+hmac_label = hmac
+hmac_key_type = CKK_GENERIC_SECRET
+hmac_keygen_mechanism = CKM_GENERIC_SECRET_KEY_GEN
+hmac_mechanism = CKM_SHA256_HMAC
+encryption_mechanism = CKM_AES_CBC
+```
+
+By default, the application will look for the configuration file in `/etc/barbican/barbican.conf`, so copy it there.
+
+```
+cp etc/barbican/barbican.conf /etc/barbican/barbican.conf
+```
+
+## Run DB Migration
+
+```
+barbican-db-manage upgrade
+```
+
+Read more on [DB Migration](https://docs.openstack.org/barbican/latest/contributor/database_migrations.html).
+
+## Generate MKEK and HMAC Keys
+
+Navigate into the Barbican project and run:
+
+```
+barbican-manage hsm gen_mkek \
+  --library-path /usr/local/lib/softhsm/libsofthsm2.so \
+  --slot-id <slot_id> \
+  --label mkek \
+  --passphrase <crypto_user_pin>
+```
+
+```
+barbican-manage hsm gen_hmac \
+  --library-path /usr/local/lib/softhsm/libsofthsm2.so \
+  --slot-id <slot_id> \
+  --label hmac \
+  --passphrase <crypto_user_pin>
+```
+
+Alternatively this can also be done via the pkcs11-tool:
+
+```
+pkcs11-tool --module /usr/local/lib/softhsm/libsofthsm2.so \
+  --slot <slot_id> \
+  --login --login-type user --pin <crypto_user_pin> \
+  --keygen --key-type AES:32 \
+  --label "mkek" \
+  --id 01 \
+  --usage-decrypt
+```
+
+```
+pkcs11-tool --module /usr/local/lib/softhsm/libsofthsm2.so \
+  --slot <slot_id> \
+  --login --login-type user --pin <crypto_user_pin> \
+  --keygen --key-type generic:32 \
+  --label "hmac" \
+  --id 02 \
+  --usage-sign
+```
+
+Show objects on token:
+
+```
+pkcs11-tool --module /usr/local/lib/softhsm/libsofthsm2.so -O \
+  --token-label <label> \
+  --pin <crypto_user_pin>
+```
+
+## Create HSM Partition Config
+
+Create HSM partition config for the project in the DB:
+
+```
+python ./barbican/cmd/hsm_partition_create.py \
+  --external-project-id <project_name> \
+  --token-label <label> \
+  --slot-id <slot_id> \
+  --password <crypto_user_pin> \
+  --library-path /usr/local/lib/softhsm/libsofthsm2.so
+```
+
+## Run Unit Tests
+
+Run unit tests by using the sample config file:
+
+```
+cp etc/barbican/barbican.conf.sample /etc/barbican/barbican.conf
+```
+
+```
+pytest --disable-warnings barbican/tests/
+```
+
+## Run Barbican
+
+Finally run the application:
+
+```
+./bin/barbican.sh start
+```
+
+## Manage Secrets using API
+
+List secret stores:
+
+```
+curl -s -X GET \
+  http://localhost:9311/v1/secret-stores \
+  -H "Content-Type: application/json" \
+  -H "X-Project-ID: <project_name>" | jq .
+```
+
+Assign secret store to project:
+
+```
+curl -X POST \
+  http://localhost:9311/v1/secret-stores/<store_uuid>/preferred \
+  -H "X-Project-ID: <project_name>"
+```
+
+Create a secret:
+
+```
+curl -s -X POST \
+  http://localhost:9311/v1/secrets \
+  -H "Content-Type: application/json" \
+  -H "X-Project-ID: <project_name>" \
+  -d '{"name": "<name>", 
+       "algorithm": "AES", 
+       "bit_length": 256, 
+       "mode": "CBC", 
+       "payload": "<payload_in_base64>", 
+       "payload_content_type": "application/octet-stream", 
+       "payload_content_encoding": "base64", 
+       "secret_type": "passphrase"}' | jq .
+```
+
+List secrets:
+
+```
+curl -s -X GET \
+  http://localhost:9311/v1/secrets \
+  -H "Content-Type: application/json" \
+  -H "X-Project-ID: <project_name>" | jq .
+```
+
+Get secret payload:
+
+```
+curl -X GET \
+  http://localhost:9311/v1/secrets/<uuid>/payload \
+  -H "Content-Type: application/json" \
+  -H "X-Project-ID: <project_name>"
+```
+
+Check [API documentation](https://docs.openstack.org/barbican/latest/api/index.html) for further details.


### PR DESCRIPTION
**ToDo:**
- A getting started guide to run Barbican with SoftHSM integration simulating multi-tenancy with Thales and 
Utimaco devices for local development.
- Integration tests for secrets with SoftHSM.