### PR TITLE
[Barbican] Initial setup to support 2025.2 Release

### DIFF
--- a/barbican/api/__init__.py
+++ b/barbican/api/__init__.py
@@ -98,8 +98,10 @@ def generate_safe_exception_message(operation_name, excep):
     except (policy.PolicyNotAuthorized, policy.InvalidScope):
         message = u._(
             '{operation} attempt not allowed - '
-            'please review your '
-            'user/project privileges').format(operation=operation_name)
+            'please ensure you have the necessary '
+            'keymanager_viewer or keymanager_admin '
+            'project roles for this operation'
+        ).format(operation=operation_name)
         status = 403
 
     except exception.BarbicanHTTPException as http_exception:

--- a/barbican/model/repositories.py
+++ b/barbican/model/repositories.py
@@ -666,14 +666,15 @@ class SecretRepo(BaseRepo):
 
     def _do_build_get_query(self, entity_id, external_project_id, session):
         """Sub-class hook: build a retrieve query."""
-        utcnow = timeutils.utcnow()
+        # utcnow = timeutils.utcnow()
 
-        expiration_filter = or_(models.Secret.expiration.is_(None),
-                                models.Secret.expiration > utcnow)
+        # Allow to fetch expired Secrets.
+        # expiration_filter = or_(models.Secret.expiration.is_(None),
+        #                        models.Secret.expiration > utcnow)
 
         query = session.query(models.Secret)
         query = query.filter_by(id=entity_id, deleted=False)
-        query = query.filter(expiration_filter)
+        # query = query.filter(expiration_filter)
         query = query.join(models.Project)
         query = query.filter(models.Project.external_id == external_project_id)
         return query
@@ -689,13 +690,14 @@ class SecretRepo(BaseRepo):
         :param session: existing db session reference.
         """
 
-        utcnow = timeutils.utcnow()
-        expiration_filter = or_(models.Secret.expiration.is_(None),
-                                models.Secret.expiration > utcnow)
+        # utcnow = timeutils.utcnow()
+        # Allow to fetch expired Secrets with a given project.
+        # expiration_filter = or_(models.Secret.expiration.is_(None),
+        #                        models.Secret.expiration > utcnow)
 
         query = session.query(models.Secret).filter_by(deleted=False)
         query = query.filter(models.Secret.project_id == project_id)
-        query = query.filter(expiration_filter)
+        # query = query.filter(expiration_filter)
 
         return query
 
@@ -761,13 +763,14 @@ class SecretRepo(BaseRepo):
         """Gets secret by its entity id without project id check."""
         session = self.get_session(session)
         try:
-            utcnow = timeutils.utcnow()
-            expiration_filter = or_(models.Secret.expiration.is_(None),
-                                    models.Secret.expiration > utcnow)
+            # utcnow = timeutils.utcnow()
+            # Allow to fetch expired Secrets without project id check.
+            # expiration_filter = or_(models.Secret.expiration.is_(None),
+            #                        models.Secret.expiration > utcnow)
 
             query = session.query(models.Secret)
             query = query.filter_by(id=entity_id, deleted=False)
-            query = query.filter(expiration_filter)
+            # query = query.filter(expiration_filter)
             entity = query.one()
         except sa_orm.exc.NoResultFound:
             entity = None
@@ -1679,16 +1682,17 @@ class CertificateAuthorityRepo(BaseRepo):
 
     def _do_build_get_query(self, entity_id, external_project_id, session):
         """Sub-class hook: build a retrieve query."""
-        utcnow = timeutils.utcnow()
+        # utcnow = timeutils.utcnow()
 
         # TODO(jfwood): Performance? Is the many-to-many join needed?
-        expiration_filter = or_(
-            models.CertificateAuthority.expiration.is_(None),
-            models.CertificateAuthority.expiration > utcnow)
+        # Allow to fetch expired Secrets.
+        # expiration_filter = or_(
+        #    models.CertificateAuthority.expiration.is_(None),
+        #    models.CertificateAuthority.expiration > utcnow)
 
         query = session.query(models.CertificateAuthority)
         query = query.filter_by(id=entity_id, deleted=False)
-        query = query.filter(expiration_filter)
+        # query = query.filter(expiration_filter)
 
         return query
 

--- a/barbican/tests/model/repositories/test_repositories_secrets.py
+++ b/barbican/tests/model/repositories/test_repositories_secrets.py
@@ -246,7 +246,7 @@ class WhenTestingSecretRepository(database_utils.RepositoryTestCase):
         session.commit()
 
         count = self.repo.get_count(project.id, session=session)
-        self.assertEqual(1, count)
+        self.assertEqual(2, count)
 
 
 class WhenTestingQueryFilters(testtools.TestCase,

--- a/concourse_unit_test_task
+++ b/concourse_unit_test_task
@@ -1,8 +1,8 @@
 export DEBIAN_FRONTEND=noninteractive && \
 export UPPER_CONSTRAINTS_FILE=https://raw.githubusercontent.com/sapcc/requirements/stable/2025.2-m3/upper-constraints.txt && \
 apt-get update && \
-apt-get install -y build-essential python3-pip python3-dev git libpcre3-dev gettext libcap2 ssh && \
-pip3 install "tox<4.0" && \
+apt-get install -y build-essential python3-pip python3-dev git libpcre3-dev gettext qemu-utils && \
+pip3 install "tox<4.0" --break-system-packages && \
 git clone -b stable/2025.2-m3 --single-branch https://github.com/sapcc/barbican.git --depth=1 && \
 cd barbican && \
-tox -r -e py310
+tox -e pep8,py312

--- a/concourse_unit_test_task
+++ b/concourse_unit_test_task
@@ -1,0 +1,8 @@
+export DEBIAN_FRONTEND=noninteractive && \
+export UPPER_CONSTRAINTS_FILE=https://raw.githubusercontent.com/sapcc/requirements/stable/2025.2-m3/upper-constraints.txt && \
+apt-get update && \
+apt-get install -y build-essential python3-pip python3-dev git libpcre3-dev gettext libcap2 ssh && \
+pip3 install "tox<4.0" && \
+git clone -b stable/2025.2-m3 --single-branch https://github.com/sapcc/barbican.git --depth=1 && \
+cd barbican && \
+tox -r -e py310

--- a/custom-requirements.txt
+++ b/custom-requirements.txt
@@ -1,0 +1,6 @@
+paste
+
+git+https://github.com/sapcc/openstack-watcher-middleware.git#egg=watcher-middleware
+git+https://github.com/sapcc/openstack-audit-middleware.git@master#egg=audit-middleware
+git+https://github.com/sapcc/openstack-rate-limit-middleware.git#egg=rate-limit-middleware
+git+https://github.com/sapcc/raven-python.git@ccloud#egg=raven

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ oslo.i18n>=3.15.3 # Apache-2.0
 oslo.messaging>=14.1.0 # Apache-2.0
 oslo.middleware>=3.31.0 # Apache-2.0
 oslo.log>=4.3.0 # Apache-2.0
-oslo.policy>=4.5.0 # Apache-2.0
+oslo.policy>=4.4.0 # Apache-2.0
 oslo.serialization!=2.19.1,>=2.18.0 # Apache-2.0
 oslo.service[threading]>=4.2.0 # Apache-2.0
 oslo.upgradecheck>=1.3.0 # Apache-2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,9 @@ dogtag =
 kmip =
   pykmip>=0.7.0 # Apache 2.0 License
 
+[options]
+scripts = bin/barbican-api
+
 [entry_points]
 oslo.policy.enforcer =
     barbican = barbican.common.policy:get_enforcer

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,8 @@ deps =
   -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/2025.2}
   -r{toxinidir}/requirements.txt
   -r{toxinidir}/test-requirements.txt
+  -r{toxinidir}/custom-requirements.txt
+
 commands =
   oslo-config-generator --config-file etc/oslo-config-generator/barbican.conf --output-file etc/barbican/barbican.conf
   coverage erase


### PR DESCRIPTION
- update barbican-cmd
- Update Safe message with project roles
- Allow query to fetch disabled secrets
- Barbican disables secrets post expiration time, which caused issues in Octavia since users forget to renew their secrets in time. This fix allows the query to fetch expired secrets.
- remove utcnowtimeutils.utcnow() in unused functions

fix conflict