### PR TITLE
Fix TypeError when SimpleCrypto KEK is not configured

### DIFF
--- a/barbican/plugin/crypto/simple_crypto.py
+++ b/barbican/plugin/crypto/simple_crypto.py
@@ -55,9 +55,16 @@ class SimpleCryptoPlugin(c.CryptoPluginBase):
     """Insecure implementation of the crypto plugin."""
 
     def __init__(self, conf=CONF):
-        if len(conf.simple_crypto_plugin.kek) < 1:
-            raise ValueError(u._("SimpleCrypto KEK is undefined"))
-        self.master_keys = conf.simple_crypto_plugin.kek
+        kek = conf.simple_crypto_plugin.kek
+        if not kek or len(kek) < 1:
+            raise ValueError(u._(
+                "SimpleCrypto KEK is undefined. "
+                "Please configure [simple_crypto_plugin] kek option. "
+                "You can generate a Fernet key using: "
+                "python3 -c 'from cryptography.fernet import Fernet; "
+                "print(Fernet.generate_key().decode())'"
+            ))
+        self.master_keys = kek
         self.plugin_name = conf.simple_crypto_plugin.plugin_name
         LOG.info("{} initialized".format(self.plugin_name))
 

--- a/barbican/plugin/util/multiple_backends.py
+++ b/barbican/plugin/util/multiple_backends.py
@@ -156,8 +156,28 @@ def sync_secret_stores(secretstore_manager, crypto_manager=None):
 
         if crypto_plugin:
             friendly_name = crypto_friendly_names.get(crypto_plugin)
+            if not friendly_name:
+                LOG.error(
+                    "Crypto plugin '%s' is configured in secretstore but "
+                    "failed to initialize. Check plugin configuration.",
+                    crypto_plugin
+                )
+                raise exception.MultipleStorePluginValueMissing(
+                    "Crypto plugin '{}' is configured but failed to "
+                    "initialize. Ensure the plugin's configuration section "
+                    "is properly set up.".format(crypto_plugin)
+                )
         else:
             friendly_name = ss_friendly_names.get(parsed_store.store_plugin)
+            if not friendly_name:
+                LOG.error(
+                    "Store plugin '%s' is configured but failed to initialize.",
+                    parsed_store.store_plugin
+                )
+                raise exception.MultipleStorePluginValueMissing(
+                    "Store plugin '{}' is configured but failed to "
+                    "initialize.".format(parsed_store.store_plugin)
+                )
 
         conf_stores.append(db_models.SecretStores(
             name=friendly_name, store_plugin=parsed_store.store_plugin,

--- a/barbican/plugin/util/multiple_backends.py
+++ b/barbican/plugin/util/multiple_backends.py
@@ -171,7 +171,8 @@ def sync_secret_stores(secretstore_manager, crypto_manager=None):
             friendly_name = ss_friendly_names.get(parsed_store.store_plugin)
             if not friendly_name:
                 LOG.error(
-                    "Store plugin '%s' is configured but failed to initialize.",
+                    "Store plugin '%s' is configured but failed to "
+                    "initialize.",
                     parsed_store.store_plugin
                 )
                 raise exception.MultipleStorePluginValueMissing(


### PR DESCRIPTION
This commit fixes two related issues that occur when the SimpleCrypto plugin is configured but the KEK (Key Encryption Key) is not set:

1. TypeError in simple_crypto.py:
   - The upstream commit 5250c5f3 removed the default KEK value for security reasons
   - When kek is None (not configured), len(None) raises TypeError
   - Fix: Add 'not kek or' check before len() to properly handle None

2. MissingArgumentError in multiple_backends.py:
   - When a plugin fails to initialize, ext.obj is None
   - get_friendly_name_dict() skips failed plugins
   - sync_secret_stores() then tries to create SecretStores with name=None
   - Fix: Add validation to raise a clear error when a configured plugin fails to initialize

Root cause: Upstream OpenStack Barbican 2025.2 (Flamingo) removed the default KEK value in commit 5250c5f3 for security reasons. This is the correct behavior, but the error handling was incomplete.

These fixes provide clear error messages instead of cryptic TypeErrors, helping operators quicklhelping operators quicklhelping operators quicklhelping operators qenancy support