### PR TITLE
Cherry-pick upstream bugfixes into stable/2025.2-m3

### DIFF
--- a/api-guide/source/secrets.rst
+++ b/api-guide/source/secrets.rst
@@ -140,6 +140,11 @@ How to Delete a Secret
 To delete a secret we will need to know the secret reference provided via
 the initial creation (See :ref:`How to Create a Secret <create_secret>`.)
 
+Starting with microversion 1.2 deleting a secret that has secret consumers
+registered will result in 400 Bad Request and the secret consumers must be
+deleted before deleting the secret. This can be overridden by passing the
+``force`` query parameter in the URL.
+
 .. code-block:: bash
 
     curl -X DELETE -H "X-Auth-Token: $TOKEN" \

--- a/barbican/api/controllers/secrets.py
+++ b/barbican/api/controllers/secrets.py
@@ -418,6 +418,18 @@ class SecretsController(controllers.ACLMixin):
             sort=kw.get('sort')
         )
 
+        # Get the query parameters
+        query_param = pecan.request.GET.mixed()
+
+        # filter out offset and limit
+        filtered_query = {
+            key: val for key, val in query_param.items()
+            if key not in ['limit', 'offset']
+        }
+
+        # parsed into url string
+        query_string = parse.urlencode(filtered_query, doseq=True)
+
         secrets, offset, limit, total = result
 
         if not secrets:
@@ -428,9 +440,11 @@ class SecretsController(controllers.ACLMixin):
                 hrefs.convert_to_hrefs(secret_fields(s))
                 for s in secrets
             ]
+            # Add filtered query_string to pagination link
             secrets_resp_overall = hrefs.add_nav_hrefs(
                 'secrets', offset, limit, total,
-                {'secrets': secrets_resp}
+                {'secrets': secrets_resp},
+                query_string=query_string
             )
             secrets_resp_overall.update({'total': total})
 

--- a/barbican/api/controllers/secrets.py
+++ b/barbican/api/controllers/secrets.py
@@ -10,6 +10,7 @@
 #  License for the specific language governing permissions and limitations
 #  under the License.
 
+from oslo_utils import strutils
 from oslo_utils import timeutils
 import pecan
 from urllib import parse
@@ -259,6 +260,19 @@ class SecretController(controllers.ACLMixin):
             self.secret.id,
             suppress_exception=True
         )
+
+        no_delete_if_consumers = versions.is_supported(
+            pecan.request, min_version='1.2')
+        if no_delete_if_consumers:
+            force = False
+            if 'force' in kwargs:
+                try:
+                    force = strutils.bool_from_string(
+                        kwargs['force'], strict=True)
+                except ValueError:
+                    _bad_query_string_parameters()
+            if len(secret_consumers[0]) > 0 and not force:
+                raise exception.SecretHasConsumers()
 
         # With ACL support, the user token project does not have to be same as
         # project associated with secret. The lookup project_id needs to be

--- a/barbican/api/controllers/versions.py
+++ b/barbican/api/controllers/versions.py
@@ -27,8 +27,8 @@ from barbican import version
 LOG = utils.getLogger(__name__)
 
 _MIN_MICROVERSION = 0
-_MAX_MICROVERSION = 1
-_LAST_UPDATED = '2021-02-10T00:00:00Z'
+_MAX_MICROVERSION = 2
+_LAST_UPDATED = '2025-09-18T00:00:00Z'
 
 # NOTE(xek): The above defines the minimum and maximum version of the API
 # across all of the v1 REST API.

--- a/barbican/common/exception.py
+++ b/barbican/common/exception.py
@@ -168,6 +168,12 @@ class NoDataToProcess(BarbicanHTTPException):
     status_code = 400
 
 
+class SecretHasConsumers(BarbicanHTTPException):
+    message = u._("Secret cannot be deleted as it has consumers.")
+    client_message = message
+    status_code = 400
+
+
 class LimitExceeded(BarbicanHTTPException):
     message = u._("The request returned a 413 Request Entity Too Large. This "
                   "generally means that rate limiting or a quota threshold "

--- a/barbican/common/hrefs.py
+++ b/barbican/common/hrefs.py
@@ -85,7 +85,8 @@ def convert_to_hrefs(fields):
     return fields
 
 
-def convert_list_to_href(resources_name, offset, limit):
+def convert_list_to_href(resources_name, offset, limit,
+                         query_string=None):
     """Supports pretty output of paged-list hrefs.
 
     Convert the offset/limit info to a HATEOAS-style href
@@ -93,10 +94,18 @@ def convert_list_to_href(resources_name, offset, limit):
     """
     resource = '{0}?limit={1}&offset={2}'.format(resources_name, limit,
                                                  offset)
+    # Append urlencoded query_String
+    if query_string:
+        # checks for existing query parameters
+        if '?' in resource:
+            resource += '&' + query_string
+        else:
+            resource += '?' + query_string
+
     return utils.hostname_for_refs(resource=resource)
 
 
-def previous_href(resources_name, offset, limit):
+def previous_href(resources_name, offset, limit, query_string=None):
     """Supports pretty output of previous-page hrefs.
 
     Create a HATEOAS-style 'previous' href suitable for use in a list
@@ -104,10 +113,11 @@ def previous_href(resources_name, offset, limit):
     currently viewed page.
     """
     offset = max(0, offset - limit)
-    return convert_list_to_href(resources_name, offset, limit)
+    return convert_list_to_href(resources_name, offset,
+                                limit, query_string)
 
 
-def next_href(resources_name, offset, limit):
+def next_href(resources_name, offset, limit, query_string=None):
     """Supports pretty output of next-page hrefs.
 
     Create a HATEOAS-style 'next' href suitable for use in a list
@@ -115,27 +125,29 @@ def next_href(resources_name, offset, limit):
     currently viewed page.
     """
     offset = offset + limit
-    return convert_list_to_href(resources_name, offset, limit)
+    return convert_list_to_href(resources_name, offset,
+                                limit, query_string)
 
 
 def add_nav_hrefs(resources_name, offset, limit,
-                  total_elements, data):
+                  total_elements, data, query_string=None):
     """Adds next and/or previous hrefs to paged list responses.
 
     :param resources_name: Name of api resource
     :param offset: Element number (ie. index) where current page starts
     :param limit: Max amount of elements listed on current page
     :param total_elements: Total number of elements
+    :param query_string: Additional query parameters passed or None is empty
     :returns: augmented dictionary with next and/or previous hrefs
     """
     if offset > 0:
         data.update({'previous': previous_href(resources_name,
                                                offset,
-                                               limit)})
+                                               limit, query_string)})
     if total_elements > (offset + limit):
         data.update({'next': next_href(resources_name,
                                        offset,
-                                       limit)})
+                                       limit, query_string)})
     return data
 
 

--- a/barbican/plugin/util/translations.py
+++ b/barbican/plugin/util/translations.py
@@ -104,7 +104,15 @@ def denormalize_after_decryption(unencrypted, content_type):
 
     # Process binary type.
     elif content_type in mime_types.BINARY:
-        unencrypted = base64.decode_as_bytes(unencrypted)
+        # Some backends (e.g. Castellan / Vault) don't store their secrets
+        # in base64, causing a failure here.  There's still a chance that
+        # raw format data could be valid base64 input, but at least this
+        # will work for most cases.
+        try:
+            unencrypted = base64.decode_as_bytes(unencrypted)
+        except Exception:
+            # Just using "pass" here won't pass PEP8.
+            return unencrypted
     else:
         raise s.SecretContentTypeNotSupportedException(content_type)
 

--- a/barbican/tests/api/controllers/test_secrets.py
+++ b/barbican/tests/api/controllers/test_secrets.py
@@ -662,6 +662,111 @@ class WhenGettingPuttingOrDeletingSecret(utils.BarbicanAPIBaseTestCase):
 
         self.assertEqual(204, delete_resp.status_int)
 
+    def test_delete_secret_with_consumers_version_1_1(self):
+        utils.set_version(self.app, '1.1')
+        resp, secret_uuid = create_secret(self.app)
+        self.assertEqual(201, resp.status_int)
+
+        consumer_dict = {
+            'service': 'service_a',
+            'resource_type': 'resource_type_a',
+            'resource_id': 'resource_id_a'}
+        consumer_resp, consumer = create_secret_consumer(
+            self.app,
+            secret_id=secret_uuid,
+            service=consumer_dict["service"],
+            resource_type=consumer_dict["resource_type"],
+            resource_id=consumer_dict["resource_id"],
+        )
+        self.assertEqual(200, consumer_resp.status_int)
+        self.assertEqual([consumer_dict], consumer)
+
+        # Pass an invalid force parameter to make sure it's
+        # ignored when not using microversion 1.2
+        params = {'force': 'abc'}
+        delete_resp = self.app.delete(
+            '/secrets/{0}/'.format(secret_uuid), params
+        )
+        self.assertEqual(204, delete_resp.status_int)
+
+    def _test_delete_secret_with_consumers_version_1_2(self, force=False):
+        utils.set_version(self.app, '1.2')
+        resp, secret_uuid = create_secret(self.app)
+        self.assertEqual(201, resp.status_int)
+
+        consumer_dict = {
+            'service': 'service_a',
+            'resource_type': 'resource_type_a',
+            'resource_id': 'resource_id_a'}
+        consumer_resp, consumer = create_secret_consumer(
+            self.app,
+            secret_id=secret_uuid,
+            service=consumer_dict["service"],
+            resource_type=consumer_dict["resource_type"],
+            resource_id=consumer_dict["resource_id"],
+        )
+        self.assertEqual(200, consumer_resp.status_int)
+        self.assertEqual([consumer_dict], consumer)
+
+        if force:
+            # Test with invalid force value
+            params = {'force': 'abc'}
+            delete_resp = self.app.delete(
+                '/secrets/{0}/'.format(secret_uuid), params,
+                expect_errors=True
+            )
+            self.assertIn(
+                'URI provided invalid query string parameters',
+                delete_resp.text)
+            self.assertEqual(400, delete_resp.status_int)
+
+            # Test with valid truthy force value
+            params = {'force': 1}
+            delete_resp = self.app.delete(
+                '/secrets/{0}/'.format(secret_uuid), params
+            )
+            self.assertEqual(204, delete_resp.status_int)
+        else:
+            # Test with value falsy force value
+            params = {'force': False}
+            delete_resp = self.app.delete(
+                '/secrets/{0}/'.format(secret_uuid), params,
+                expect_errors=True
+            )
+            self.assertIn(
+                'Secret cannot be deleted as it has consumers',
+                delete_resp.text)
+            self.assertEqual(400, delete_resp.status_int)
+
+            # Test without force
+            delete_resp = self.app.delete(
+                '/secrets/{0}/'.format(secret_uuid),
+                expect_errors=True
+            )
+            self.assertIn(
+                'Secret cannot be deleted as it has consumers',
+                delete_resp.text)
+            self.assertEqual(400, delete_resp.status_int)
+
+            # Delete consumer
+            consumer_del_resp = self.app.delete_json(
+                '/secrets/{secret_id}/consumers/'.format(
+                    secret_id=secret_uuid
+                ), consumer_dict, headers={'Content-Type': 'application/json'})
+            self.assertEqual(200, consumer_del_resp.status_int)
+
+            # Deleting without force should work
+            delete_resp = self.app.delete(
+                '/secrets/{0}/'.format(secret_uuid)
+            )
+            self.assertEqual(204, delete_resp.status_int)
+
+    def test_delete_secret_with_consumers_version_1_2(self):
+        self._test_delete_secret_with_consumers_version_1_2()
+
+    def test_delete_secret_with_consumers_version_1_2_force(self):
+        self._test_delete_secret_with_consumers_version_1_2(force=True)
+
     def test_raise_404_for_delete_secret_not_found(self):
         delete_resp = self.app.delete(
             '/secrets/98c876d9-aaac-44e4-8ea8-441932962b05',
@@ -871,3 +976,27 @@ def create_secret(app, name=None, algorithm=None, bit_length=None, mode=None,
         _, created_uuid = os.path.split(secret_ref)
 
     return resp, created_uuid
+
+
+def create_secret_consumer(app, secret_id=None, service=None,
+                           resource_type=None, resource_id=None,
+                           expect_errors=False, headers=None):
+    request = {
+        "service": service,
+        "resource_type": resource_type,
+        "resource_id": resource_id,
+    }
+    request = {k: v for k, v in request.items() if v is not None}
+
+    resp = app.post_json(
+        "/secrets/{}/consumers/".format(secret_id),
+        request,
+        expect_errors=expect_errors,
+        headers=headers
+    )
+
+    consumers = None
+    if resp.status_int == 200:
+        consumers = resp.json.get('consumers', '')
+
+    return resp, consumers

--- a/doc/source/api/microversion_history.rst
+++ b/doc/source/api/microversion_history.rst
@@ -28,3 +28,9 @@ Added Secret Consumers to Secrets.
 
 When requesting Secrets (individual Secret or a list), the results contain an
 additional ``consumers`` key, which contains references to Secret Consumers.
+
+1.2 (Maximum in Hibiscus)
+---
+
+Deleting a secret that has consumers is rejected in the
+API unless the ``force`` query parameter is sent.

--- a/releasenotes/notes/delete-secret-with-consumers-microversion-0f0ee09eaf7624d9.yaml
+++ b/releasenotes/notes/delete-secret-with-consumers-microversion-0f0ee09eaf7624d9.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    Barbican now has a new microversion 1.2 with a behaviour change when
+    deleting secrets. If a secret has consumers registered it cannot be
+    deleted in this microversion until the consumers are removed.
+
+    Use the ``force`` query parameter with a truthy value to force the
+    deletion.


### PR DESCRIPTION
## Summary

Cherry-picks three upstream fixes from openstack/barbican master into the `stable/2025.2-m3` branch:

- **Updated pagination logic to preserve URL filters** ([4f90025f](https://github.com/openstack/barbican/commit/4f90025f1a932ca73b2ef78b6d97c71b96be5bdc))
  - Fixes [bug #2064583](https://bugs.launchpad.net/barbican/+bug/2064583): pagination next/prev URLs were dropping query filters (e.g. `acl_only`, `secret_type`)

- **Fix exception when retrieving binary secrets that are not base64-encoded** ([5ff5e44c](https://github.com/openstack/barbican/commit/5ff5e44c6c25d0a5aceee38379637ef5ad017b2d))
  - Fixes [bug #2113749](https://bugs.launchpad.net/barbican/+bug/2113749): retrieving binary secrets stored without base64 encoding (e.g. via Castellan/Vault) raised an unhandled exception

- **Don't allow deleting secrets with consumers** ([2d1ea860](https://github.com/openstack/barbican/commit/2d1ea8606784cb7e1147e869a79f6be7e8466236))
  - New microversion 1.2: prevents deletion of secrets with registered consumers unless `?force=true` is passed

## Test plan

- [x] Unit tests pass (`tox -e py3`)
- [x] Pagination: verify filters are preserved in `next`/`previous` hrefs
- [x] Binary secret retrieval: verify non-base64 secrets are returned without exception
- [x] Consumer protection: verify DELETE on a secret with consumers returns 409, and succeeds with `?force=true`