### PR TITLE
[SAP] Fix unbatched DB cleanup causing InnoDB buffer pool exhaustion

### DIFF
--- a/barbican/model/clean.py
+++ b/barbican/model/clean.py
@@ -59,7 +59,7 @@ def cleanup_unassociated_projects():
     sub_query = sa_sql.select(sub_query)
     query = session.query(models.Project)
     query = query.filter(models.Project.id.in_(sub_query))
-    delete_count = query.delete(synchronize_session='fetch')
+    delete_count = query.delete(synchronize_session=False)
     LOG.info("Cleaned up %(delete_count)s entries for "
              "%(project_name)s",
              {'delete_count': str(delete_count),
@@ -97,7 +97,7 @@ def cleanup_parent_with_no_child(parent_model, child_model,
     query = query.filter(parent_model.deleted)
     if threshold_date:
         query = query.filter(parent_model.deleted_at <= threshold_date)
-    delete_count = query.delete(synchronize_session='fetch')
+    delete_count = query.delete(synchronize_session=False)
     LOG.info("Cleaned up %(delete_count)s entries for %(parent_name)s "
              "with no children in %(child_name)s",
              {'delete_count': delete_count,
@@ -106,24 +106,39 @@ def cleanup_parent_with_no_child(parent_model, child_model,
     return delete_count
 
 
-def cleanup_softdeletes(model, threshold_date=None):
-    """Remove soft deletions from a table.
+def cleanup_softdeletes(model, threshold_date=None, batch_size=10000):
+    """Remove soft deletions from a table in batches.
+
+    Processes rows in batches and commits after each batch to avoid
+    exhausting the InnoDB buffer pool and undo log on large tables.
 
     :param model: table class to remove soft deletions
     :param threshold_date: soft deletions older than this date will be removed
+    :param batch_size: number of rows to delete per batch
     :returns: total number of entries removed from the database
     """
     LOG.debug("Cleaning soft deletes: %s", model.__name__)
-    session = repo.get_session()
-    query = session.query(model)
-    query = query.filter_by(deleted=True)
-    if threshold_date:
-        query = query.filter(model.deleted_at <= threshold_date)
-    delete_count = query.delete()
+    total = 0
+    while True:
+        session = repo.get_session()
+        id_query = session.query(model.id).filter_by(deleted=True)
+        if threshold_date:
+            id_query = id_query.filter(model.deleted_at <= threshold_date)
+        ids = [row[0] for row in id_query.limit(batch_size).all()]
+        if not ids:
+            break
+        count = session.query(model).filter(
+            model.id.in_(ids)).delete(synchronize_session=False)
+        # Detach all ORM objects before committing so that expire_on_commit
+        # does not clear their __dict__. Test code and callers holding object
+        # references can still read pk attributes from the detached state.
+        session.expunge_all()
+        repo.commit()
+        total += count
     LOG.info("Cleaned up %(delete_count)s entries for %(model_name)s",
-             {'delete_count': delete_count,
+             {'delete_count': total,
               'model_name': model.__name__})
-    return delete_count
+    return total
 
 
 def cleanup_all(threshold_date=None):
@@ -197,7 +212,7 @@ def _soft_delete_expired_secrets(threshold_date):
             models.Secret.deleted: True,
             models.Secret.deleted_at: current_time
         },
-        synchronize_session='fetch')
+        synchronize_session=False)
     return update_count
 
 
@@ -218,7 +233,7 @@ def _hard_delete_acls_for_soft_deleted_secrets():
     acl_user_query = session.query(models.SecretACLUser)
     acl_user_query = acl_user_query.filter(
         models.SecretACLUser.id.in_(acl_user_sub_query))
-    acl_total = acl_user_query.delete(synchronize_session='fetch')
+    acl_total = acl_user_query.delete(synchronize_session=False)
 
     acl_sub_query = session.query(models.SecretACL.id)
     acl_sub_query = acl_sub_query.join(models.Secret)
@@ -229,16 +244,19 @@ def _hard_delete_acls_for_soft_deleted_secrets():
     acl_query = session.query(models.SecretACL)
     acl_query = acl_query.filter(
         models.SecretACL.id.in_(acl_sub_query))
-    acl_total += acl_query.delete(synchronize_session='fetch')
+    acl_total += acl_query.delete(synchronize_session=False)
     return acl_total
 
 
-def _soft_delete_expired_secret_children(threshold_date):
+def _soft_delete_expired_secret_children(threshold_date, batch_size=10000):
     """Soft delete the children tables of expired secrets.
 
-    Soft deletes the children tables  and hard deletes the ACL children
-    tables of the expired secrets.
+    Soft deletes the children tables and hard deletes the ACL children
+    tables of the expired secrets. Processes rows in batches and commits
+    after each batch to avoid unbatched SELECT/UPDATE on large tables.
+
     :param threshold_date: threshold date for secret expiration
+    :param batch_size: number of rows to update per batch
     :returns: returns a pair for number of soft delete children and deleted
               ACLs
     """
@@ -251,29 +269,30 @@ def _soft_delete_expired_secret_children(threshold_date):
     children_names = map(lambda child: child.__name__, secret_children)
     LOG.debug("Children tables for Secret table being checked: %s",
               str(children_names))
-    session = repo.get_session()
     update_count = 0
 
     for table in secret_children:
-        # Go through children and soft delete them
-        sub_query = session.query(table.id)
-        sub_query = sub_query.join(models.Secret)
-        sub_query = sub_query.filter(
-            models.Secret.expiration <= threshold_date
-        )
-        sub_query = sub_query.subquery()
-        sub_query = sa_sql.select(sub_query)
-        query = session.query(table)
-        query = query.filter(table.id.in_(sub_query))
-        current_update_count = query.update(
-            {
-                table.deleted: True,
-                table.deleted_at: current_time
-            },
-            synchronize_session='fetch')
-        update_count += current_update_count
+        while True:
+            session = repo.get_session()
+            id_query = session.query(table.id)
+            id_query = id_query.join(models.Secret)
+            id_query = id_query.filter(
+                models.Secret.expiration <= threshold_date
+            )
+            id_query = id_query.filter(~table.deleted)
+            ids = [row[0] for row in id_query.limit(batch_size).all()]
+            if not ids:
+                break
+            count = session.query(table).filter(table.id.in_(ids)).update(
+                {
+                    table.deleted: True,
+                    table.deleted_at: current_time
+                },
+                synchronize_session=False)
+            session.expunge_all()
+            repo.commit()
+            update_count += count
 
-    session.flush()
     acl_total = _hard_delete_acls_for_soft_deleted_secrets()
     return update_count, acl_total
 
@@ -357,7 +376,9 @@ def clean_command(sql_url, min_num_days, do_clean_unassociated_projects,
     except Exception as ex:
         LOG.exception('Failed to clean up soft deletions in database.')
         repo.rollback()
-        cleanup_total = 0  # rollback happened, no entries affected
+        # Batched operations commit incrementally, so some rows may already
+        # be deleted. cleanup_total only reflects the current failed batch.
+        cleanup_total = 0
         raise ex
     finally:
         stop_watch.stop()

--- a/barbican/model/clean.py
+++ b/barbican/model/clean.py
@@ -37,47 +37,6 @@ DEFAULT_CLEANUP_BATCH_SIZE = 10000
 _PROGRESS_LOG_EVERY_N_BATCHES = 10
 
 
-def _batched_delete_by_id(model, id_query, batch_size, op_label):
-    """Delete rows in `model` whose ids are returned by `id_query`, batched.
-
-    Generic helper that powers all batched cleanup paths. Selects up to
-    ``batch_size`` ids per iteration, hard-deletes them, commits, and loops
-    until no more matching ids are found.
-
-    The caller's ``id_query`` MUST be constructed such that already-deleted
-    rows are excluded from subsequent iterations. For pure soft-delete-to-
-    hard-delete loops this is trivially true (the row is gone after DELETE).
-    For more complex queries the caller is responsible for the predicate.
-
-    :param model: ORM model class whose rows are to be deleted.
-    :param id_query: a SQLAlchemy Query yielding primary keys (1-tuples).
-    :param batch_size: max rows per batch.
-    :param op_label: short string used in log messages (e.g. model name).
-    :returns: total rows deleted across all committed batches.
-    """
-    total = 0
-    batch_no = 0
-    while True:
-        session = repo.get_session()
-        ids = [row[0] for row in id_query.limit(batch_size).all()]
-        if not ids:
-            break
-        count = session.query(model).filter(
-            model.id.in_(ids)).delete(synchronize_session=False)
-        # Detach all ORM objects before commit. With expire_on_commit=True
-        # (the default for the scoped session in this project), a commit
-        # would otherwise clear attached objects' __dict__, breaking
-        # callers and tests that hold references to fixture objects.
-        session.expunge_all()
-        repo.commit()
-        total += count
-        batch_no += 1
-        if batch_no % _PROGRESS_LOG_EVERY_N_BATCHES == 0:
-            LOG.debug("[%s] progress: %d batches committed, %d rows so far",
-                      op_label, batch_no, total)
-    return total
-
-
 def cleanup_unassociated_projects():
     """Clean up unassociated projects.
 

--- a/barbican/model/clean.py
+++ b/barbican/model/clean.py
@@ -28,6 +28,55 @@ CONF = config.CONF
 log.setup(CONF, 'barbican')
 LOG = log.getLogger(__name__)
 
+# Default batch size for cleanup operations. Sized so a single batch fits
+# comfortably in the InnoDB buffer pool and undo log on a 10 GB pool.
+DEFAULT_CLEANUP_BATCH_SIZE = 10000
+
+# Emit a progress log line every Nth batch so operators can monitor long
+# cleanup runs without attaching a debugger or querying the database.
+_PROGRESS_LOG_EVERY_N_BATCHES = 10
+
+
+def _batched_delete_by_id(model, id_query, batch_size, op_label):
+    """Delete rows in `model` whose ids are returned by `id_query`, batched.
+
+    Generic helper that powers all batched cleanup paths. Selects up to
+    ``batch_size`` ids per iteration, hard-deletes them, commits, and loops
+    until no more matching ids are found.
+
+    The caller's ``id_query`` MUST be constructed such that already-deleted
+    rows are excluded from subsequent iterations. For pure soft-delete-to-
+    hard-delete loops this is trivially true (the row is gone after DELETE).
+    For more complex queries the caller is responsible for the predicate.
+
+    :param model: ORM model class whose rows are to be deleted.
+    :param id_query: a SQLAlchemy Query yielding primary keys (1-tuples).
+    :param batch_size: max rows per batch.
+    :param op_label: short string used in log messages (e.g. model name).
+    :returns: total rows deleted across all committed batches.
+    """
+    total = 0
+    batch_no = 0
+    while True:
+        session = repo.get_session()
+        ids = [row[0] for row in id_query.limit(batch_size).all()]
+        if not ids:
+            break
+        count = session.query(model).filter(
+            model.id.in_(ids)).delete(synchronize_session=False)
+        # Detach all ORM objects before commit. With expire_on_commit=True
+        # (the default for the scoped session in this project), a commit
+        # would otherwise clear attached objects' __dict__, breaking
+        # callers and tests that hold references to fixture objects.
+        session.expunge_all()
+        repo.commit()
+        total += count
+        batch_no += 1
+        if batch_no % _PROGRESS_LOG_EVERY_N_BATCHES == 0:
+            LOG.debug("[%s] progress: %d batches committed, %d rows so far",
+                      op_label, batch_no, total)
+    return total
+
 
 def cleanup_unassociated_projects():
     """Clean up unassociated projects.
@@ -68,57 +117,99 @@ def cleanup_unassociated_projects():
 
 
 def cleanup_parent_with_no_child(parent_model, child_model,
-                                 threshold_date=None):
-    """Clean up soft deletions in parent that do not have references in child.
+                                 threshold_date=None,
+                                 batch_size=DEFAULT_CLEANUP_BATCH_SIZE):
+    """Clean up soft-deleted parents that have no live child rows, in batches.
 
-    Before running this function, the child table should be cleaned of
-    soft deletions. This function left outer joins the parent and child
-    tables and finds the parent entries that do not have a foreign key
-    reference in the child table. Then the results are filtered by soft
-    deletions and are cleaned up.
+    Before running this function the child table should already be cleaned
+    of soft-deleted rows. This function left-outer-joins the parent and
+    child tables and finds parent entries that have no foreign-key match
+    in the child table, then filters by soft-deletion / threshold_date and
+    hard-deletes them.
 
-    :param parent_model: table class for parent
-    :param child_model: table class for child which restricts parent deletion
-    :param threshold_date: soft deletions older than this date will be removed
-    :returns: total number of entries removed from database
+    Operates in batches of ``batch_size`` rows. Each batch is committed
+    independently so InnoDB can release pages and undo log between batches.
+    Partial progress is durable: if an exception is raised mid-run, batches
+    committed before the failure are NOT rolled back.
+
+    :param parent_model: table class for parent.
+    :param child_model: table class for child which restricts parent deletion.
+    :param threshold_date: soft deletions older than this date will be
+                           removed.
+    :param batch_size: max rows hard-deleted per committed batch.
+    :returns: total entries removed from the database.
     """
     LOG.debug("Cleaning soft deletes for %(parent_name)s without "
-              "a child in %(child_name)s" %
+              "a child in %(child_name)s",
               {'parent_name': parent_model.__name__,
                'child_name': child_model.__name__})
-    session = repo.get_session()
-    sub_query = session.query(parent_model.id)
-    sub_query = sub_query.outerjoin(child_model)
-    sub_query = sub_query.filter(child_model.id == None)  # noqa
-    sub_query = sub_query.subquery()
-    sub_query = sa_sql.select(sub_query)
-    query = session.query(parent_model)
-    query = query.filter(parent_model.id.in_(sub_query))
-    query = query.filter(parent_model.deleted)
-    if threshold_date:
-        query = query.filter(parent_model.deleted_at <= threshold_date)
-    delete_count = query.delete(synchronize_session=False)
+
+    def _id_query():
+        session = repo.get_session()
+        sub_query = session.query(parent_model.id)
+        sub_query = sub_query.outerjoin(child_model)
+        sub_query = sub_query.filter(child_model.id == None)  # noqa
+        sub_query = sub_query.filter(parent_model.deleted)
+        if threshold_date:
+            sub_query = sub_query.filter(
+                parent_model.deleted_at <= threshold_date)
+        return sub_query
+
+    # Each iteration of the batched loop re-issues the id query against a
+    # fresh session state. Because each batch hard-deletes the matched
+    # rows, the candidate set strictly shrinks across iterations and the
+    # loop terminates.
+    total = 0
+    batch_no = 0
+    label = "%s/no-%s" % (parent_model.__name__, child_model.__name__)
+    while True:
+        session = repo.get_session()
+        ids = [row[0] for row in _id_query().limit(batch_size).all()]
+        if not ids:
+            break
+        count = session.query(parent_model).filter(
+            parent_model.id.in_(ids)).delete(synchronize_session=False)
+        session.expunge_all()
+        repo.commit()
+        total += count
+        batch_no += 1
+        if batch_no % _PROGRESS_LOG_EVERY_N_BATCHES == 0:
+            LOG.debug("[%s] progress: %d batches committed, %d rows so far",
+                      label, batch_no, total)
+
     LOG.info("Cleaned up %(delete_count)s entries for %(parent_name)s "
              "with no children in %(child_name)s",
-             {'delete_count': delete_count,
+             {'delete_count': total,
               'parent_name': parent_model.__name__,
               'child_name': child_model.__name__})
-    return delete_count
+    return total
 
 
-def cleanup_softdeletes(model, threshold_date=None, batch_size=10000):
-    """Remove soft deletions from a table in batches.
+def cleanup_softdeletes(model, threshold_date=None,
+                        batch_size=DEFAULT_CLEANUP_BATCH_SIZE):
+    """Remove soft-deleted rows from a table, in batches.
 
-    Processes rows in batches and commits after each batch to avoid
-    exhausting the InnoDB buffer pool and undo log on large tables.
+    Selects up to ``batch_size`` soft-deleted ids per iteration, hard-
+    deletes them, then commits. Each commit releases InnoDB pages and undo
+    log so very large tables (millions of rows) can be cleaned without
+    exhausting the buffer pool.
 
-    :param model: table class to remove soft deletions
-    :param threshold_date: soft deletions older than this date will be removed
-    :param batch_size: number of rows to delete per batch
-    :returns: total number of entries removed from the database
+    Partial progress is durable: if an exception is raised mid-run, the
+    batches committed before the failure are NOT rolled back. This is a
+    deliberate trade-off vs. the previous one-shot semantics; without
+    incremental commits the operation is impossible to complete on tables
+    that no longer fit in the buffer pool.
+
+    :param model: table class whose soft deletions should be removed.
+    :param threshold_date: only rows soft-deleted on or before this date
+                           are removed.
+    :param batch_size: max rows hard-deleted per committed batch.
+    :returns: total rows removed from the database.
     """
     LOG.debug("Cleaning soft deletes: %s", model.__name__)
     total = 0
+    batch_no = 0
+    label = model.__name__
     while True:
         session = repo.get_session()
         id_query = session.query(model.id).filter_by(deleted=True)
@@ -129,12 +220,17 @@ def cleanup_softdeletes(model, threshold_date=None, batch_size=10000):
             break
         count = session.query(model).filter(
             model.id.in_(ids)).delete(synchronize_session=False)
-        # Detach all ORM objects before committing so that expire_on_commit
-        # does not clear their __dict__. Test code and callers holding object
-        # references can still read pk attributes from the detached state.
+        # Detach all ORM objects before commit so that expire_on_commit
+        # does not clear their __dict__. Test code and callers holding
+        # object references can still read pk attributes from the
+        # detached state.
         session.expunge_all()
         repo.commit()
         total += count
+        batch_no += 1
+        if batch_no % _PROGRESS_LOG_EVERY_N_BATCHES == 0:
+            LOG.debug("[%s] progress: %d batches committed, %d rows so far",
+                      label, batch_no, total)
     LOG.info("Cleaned up %(delete_count)s entries for %(model_name)s",
              {'delete_count': total,
               'model_name': model.__name__})
@@ -216,49 +312,81 @@ def _soft_delete_expired_secrets(threshold_date):
     return update_count
 
 
-def _hard_delete_acls_for_soft_deleted_secrets():
-    """Remove acl entries for secrets that have been soft deleted.
+def _hard_delete_acls_for_soft_deleted_secrets(
+        batch_size=DEFAULT_CLEANUP_BATCH_SIZE):
+    """Remove ACL entries for secrets that have been soft deleted, in batches.
 
-    Removes entries in SecretACL and SecretACLUser which are for secrets
-    that have been soft deleted.
+    Removes entries in :class:`models.SecretACL` and
+    :class:`models.SecretACLUser` whose owning secret has been soft deleted.
+    Each batch is committed independently so this stays within InnoDB
+    resource limits even on projects with very large ACL tables.
+
+    :param batch_size: max rows hard-deleted per committed batch.
+    :returns: total ACL rows deleted.
     """
-    session = repo.get_session()
-    acl_user_sub_query = session.query(models.SecretACLUser.id)
-    acl_user_sub_query = acl_user_sub_query.join(models.SecretACL)
-    acl_user_sub_query = acl_user_sub_query.join(models.Secret)
-    acl_user_sub_query = acl_user_sub_query.filter(models.Secret.deleted)
-    acl_user_sub_query = acl_user_sub_query.subquery()
-    acl_user_sub_query = sa_sql.select(acl_user_sub_query)
+    acl_total = 0
+    batch_no = 0
 
-    acl_user_query = session.query(models.SecretACLUser)
-    acl_user_query = acl_user_query.filter(
-        models.SecretACLUser.id.in_(acl_user_sub_query))
-    acl_total = acl_user_query.delete(synchronize_session=False)
+    # SecretACLUser rows: joined-three-table predicate (user -> ACL -> secret).
+    while True:
+        session = repo.get_session()
+        sub_query = session.query(models.SecretACLUser.id)
+        sub_query = sub_query.join(models.SecretACL)
+        sub_query = sub_query.join(models.Secret)
+        sub_query = sub_query.filter(models.Secret.deleted)
+        ids = [row[0] for row in sub_query.limit(batch_size).all()]
+        if not ids:
+            break
+        count = session.query(models.SecretACLUser).filter(
+            models.SecretACLUser.id.in_(ids)
+        ).delete(synchronize_session=False)
+        session.expunge_all()
+        repo.commit()
+        acl_total += count
+        batch_no += 1
+        if batch_no % _PROGRESS_LOG_EVERY_N_BATCHES == 0:
+            LOG.debug("[SecretACLUser] progress: %d batches committed, "
+                      "%d rows so far", batch_no, acl_total)
 
-    acl_sub_query = session.query(models.SecretACL.id)
-    acl_sub_query = acl_sub_query.join(models.Secret)
-    acl_sub_query = acl_sub_query.filter(models.Secret.deleted)
-    acl_sub_query = acl_sub_query.subquery()
-    acl_sub_query = sa_sql.select(acl_sub_query)
+    # SecretACL rows: joined-two-table predicate (ACL -> secret).
+    batch_no = 0
+    while True:
+        session = repo.get_session()
+        sub_query = session.query(models.SecretACL.id)
+        sub_query = sub_query.join(models.Secret)
+        sub_query = sub_query.filter(models.Secret.deleted)
+        ids = [row[0] for row in sub_query.limit(batch_size).all()]
+        if not ids:
+            break
+        count = session.query(models.SecretACL).filter(
+            models.SecretACL.id.in_(ids)
+        ).delete(synchronize_session=False)
+        session.expunge_all()
+        repo.commit()
+        acl_total += count
+        batch_no += 1
+        if batch_no % _PROGRESS_LOG_EVERY_N_BATCHES == 0:
+            LOG.debug("[SecretACL] progress: %d batches committed, "
+                      "%d rows so far", batch_no, acl_total)
 
-    acl_query = session.query(models.SecretACL)
-    acl_query = acl_query.filter(
-        models.SecretACL.id.in_(acl_sub_query))
-    acl_total += acl_query.delete(synchronize_session=False)
     return acl_total
 
 
-def _soft_delete_expired_secret_children(threshold_date, batch_size=10000):
-    """Soft delete the children tables of expired secrets.
+def _soft_delete_expired_secret_children(
+        threshold_date, batch_size=DEFAULT_CLEANUP_BATCH_SIZE):
+    """Soft-delete the children tables of expired secrets, in batches.
 
-    Soft deletes the children tables and hard deletes the ACL children
+    Soft-deletes the children tables and hard-deletes the ACL children
     tables of the expired secrets. Processes rows in batches and commits
     after each batch to avoid unbatched SELECT/UPDATE on large tables.
 
-    :param threshold_date: threshold date for secret expiration
-    :param batch_size: number of rows to update per batch
-    :returns: returns a pair for number of soft delete children and deleted
-              ACLs
+    The id query filters with ``~table.deleted`` so each iteration only
+    picks up rows not yet processed; this guarantees loop termination
+    because every successful batch monotonically shrinks the candidate set.
+
+    :param threshold_date: threshold date for secret expiration.
+    :param batch_size: max rows updated per committed batch.
+    :returns: pair (number of soft-deleted children, number of deleted ACLs).
     """
     current_time = timeutils.utcnow()
 
@@ -272,6 +400,8 @@ def _soft_delete_expired_secret_children(threshold_date, batch_size=10000):
     update_count = 0
 
     for table in secret_children:
+        batch_no = 0
+        label = table.__name__
         while True:
             session = repo.get_session()
             id_query = session.query(table.id)
@@ -292,8 +422,13 @@ def _soft_delete_expired_secret_children(threshold_date, batch_size=10000):
             session.expunge_all()
             repo.commit()
             update_count += count
+            batch_no += 1
+            if batch_no % _PROGRESS_LOG_EVERY_N_BATCHES == 0:
+                LOG.debug("[%s] progress: %d batches committed, "
+                          "%d rows so far", label, batch_no, update_count)
 
-    acl_total = _hard_delete_acls_for_soft_deleted_secrets()
+    acl_total = _hard_delete_acls_for_soft_deleted_secrets(
+        batch_size=batch_size)
     return update_count, acl_total
 
 
@@ -373,13 +508,18 @@ def clean_command(sql_url, min_num_days, do_clean_unassociated_projects,
         cleanup_total += cleanup_all(threshold_date=threshold_date)
         repo.commit()
 
-    except Exception as ex:
-        LOG.exception('Failed to clean up soft deletions in database.')
+    except Exception:
+        # The batched cleanup helpers commit incrementally, so on failure
+        # any batches already committed are durably persisted; only the
+        # in-flight batch is rolled back here. ``cleanup_total`` therefore
+        # reflects the rows that ARE permanently deleted up to the point
+        # of failure -- DO NOT reset it to 0, that would mislead operators
+        # during incident response.
+        LOG.exception('Failed to clean up soft deletions in database. '
+                      '%s entries were committed before the failure.',
+                      cleanup_total)
         repo.rollback()
-        # Batched operations commit incrementally, so some rows may already
-        # be deleted. cleanup_total only reflects the current failed batch.
-        cleanup_total = 0
-        raise ex
+        raise
     finally:
         stop_watch.stop()
         elapsed_time = stop_watch.elapsed()

--- a/barbican/tests/cmd/test_db_cleanup.py
+++ b/barbican/tests/cmd/test_db_cleanup.py
@@ -435,3 +435,132 @@ class WhenTestingDBCleanUpCommand(utils.RepositoryTestCase):
         secret_metadatum.deleted = False
 
         self.assertRaises(db_exc.DBReferenceError, clean.cleanup_all)
+
+    # ------------------------------------------------------------------
+    # Tests for batched cleanup behaviour
+    # ------------------------------------------------------------------
+
+    def test_cleanup_softdeletes_runs_multiple_batches(self):
+        """Process more rows than batch_size, committing per batch.
+
+        Verifies that cleanup_softdeletes re-queries for each batch and
+        commits between batches rather than deleting in a single shot.
+        """
+        # 5 soft-deleted transport keys, batch_size=2 -> expect >=3 batches.
+        keys = [_setup_entry('transport_key') for _ in range(5)]
+        for k in keys:
+            k.delete()
+
+        with mock.patch('barbican.model.clean.repo.commit',
+                        wraps=repos.commit) as mock_commit:
+            total = clean.cleanup_softdeletes(models.TransportKey,
+                                              batch_size=2)
+
+        self.assertEqual(5, total)
+        # ceil(5/2) = 3 successful batches, plus the loop exits without
+        # calling commit() for the empty trailing query -> exactly 3.
+        self.assertEqual(3, mock_commit.call_count)
+        for k in keys:
+            self.assertFalse(_entry_exists(k))
+
+    def test_cleanup_softdeletes_returns_zero_when_nothing_to_do(self):
+        """cleanup_softdeletes is a safe no-op when nothing matches."""
+        with mock.patch('barbican.model.clean.repo.commit',
+                        wraps=repos.commit) as mock_commit:
+            total = clean.cleanup_softdeletes(models.TransportKey,
+                                              batch_size=10)
+        self.assertEqual(0, total)
+        self.assertEqual(0, mock_commit.call_count)
+
+    @_create_project("batch parent no child project")
+    def test_cleanup_parent_with_no_child_runs_multiple_batches(self, project):
+        """Verify cleanup_parent_with_no_child batches its DELETE."""
+        # 5 soft-deleted secrets with no order child.
+        secrets = [_setup_entry('secret', project=project) for _ in range(5)]
+        for s in secrets:
+            s.delete()
+
+        with mock.patch('barbican.model.clean.repo.commit',
+                        wraps=repos.commit) as mock_commit:
+            total = clean.cleanup_parent_with_no_child(
+                models.Secret, models.Order, batch_size=2)
+
+        self.assertEqual(5, total)
+        self.assertEqual(3, mock_commit.call_count)
+        for s in secrets:
+            self.assertFalse(_entry_exists(s))
+
+    def test_cleanup_softdeletes_partial_progress_is_durable(self):
+        """Verify partial progress is durable on mid-loop failure.
+
+        If an exception strikes mid-loop, batches already committed
+        before the failure remain deleted -- they are NOT rolled back.
+        """
+        keys = [_setup_entry('transport_key') for _ in range(5)]
+        for k in keys:
+            k.delete()
+        ids = [k.id for k in keys]
+
+        # Make the third commit raise. The first two batches (4 rows) must
+        # remain durably deleted.
+        original_commit = repos.commit
+        call_state = {'n': 0}
+
+        def flaky_commit():
+            call_state['n'] += 1
+            if call_state['n'] == 3:
+                raise RuntimeError("boom")
+            original_commit()
+
+        with mock.patch('barbican.model.clean.repo.commit',
+                        side_effect=flaky_commit):
+            self.assertRaises(RuntimeError,
+                              clean.cleanup_softdeletes,
+                              models.TransportKey, batch_size=2)
+
+        # The in-flight (uncommitted) DELETE of the failing batch is still
+        # visible to subsequent queries on the same session. Roll it back
+        # so the count below reflects only what is durably persisted.
+        repos.rollback()
+
+        # 2 batches × 2 rows = 4 rows must be gone, 1 row remains.
+        session = repos.get_session()
+        remaining = session.query(models.TransportKey).filter(
+            models.TransportKey.id.in_(ids)).count()
+        self.assertEqual(1, remaining)
+
+    def test_hard_delete_acls_for_soft_deleted_secrets_batches(self):
+        """The ACL hard-delete path must batch its DELETEs.
+
+        Creates 4 soft-deleted secrets each with one SecretACL and two
+        SecretACLUser children. With batch_size=2 we expect:
+          - SecretACLUser: 8 rows -> ceil(8/2) = 4 batches
+          - SecretACL:    4 rows -> ceil(4/2) = 2 batches
+          - total commits: 6, total rows deleted: 12
+
+        Note: this test inlines its own project setup rather than using the
+        @_create_project decorator because the ACL cleanup path calls
+        ``session.expunge_all()`` which would detach the decorator's
+        project fixture and break its post-test cleanup.
+        """
+        project = _setup_entry('project', external_id="acl batch project")
+        session = repos.get_session()
+        for i in range(4):
+            secret = _setup_entry('secret', project=project)
+            acl = models.SecretACL(secret.id, "read")
+            acl.secret_id = secret.id
+            session.add(acl)
+            session.flush()
+            for u in ("alice-%d" % i, "bob-%d" % i):
+                acl_user = models.SecretACLUser(acl.id, u)
+                session.add(acl_user)
+            secret.deleted = True
+        repos.commit()
+
+        with mock.patch('barbican.model.clean.repo.commit',
+                        wraps=repos.commit) as mock_commit:
+            acl_total = clean._hard_delete_acls_for_soft_deleted_secrets(
+                batch_size=2)
+
+        self.assertEqual(12, acl_total)
+        self.assertEqual(6, mock_commit.call_count)


### PR DESCRIPTION
## Problem

`barbican-mariadb` in QA-DE-1 hit `MariaDBBufferPoolExhausted` (critical). Root cause: `secret_store_metadata` had grown to **10.7M rows / 3.5 GB** due to accumulated test data and HSM performance tests. `encrypted_data` (4.2M rows / 2.6 GB) and `secrets` (5.7M rows / 1.8 GB) added another ~4.4 GB, totalling ~8 GB against a 1 GB buffer pool (now bumped to 10 GB via helm-charts).

We are enabling `barbican-manage db clean` via [helm-charts PR #10672](https://github.com/sapcc/helm-charts/pull/10672) (BSI requirement) to trim this data. Before this fix, running that command would make things **worse**, not better.

## What was broken

**`cleanup_softdeletes`** — called unconditionally on every `db clean` run — issued a single bulk `DELETE` in one transaction:

```sql
DELETE FROM secret_store_metadata
WHERE deleted = 1 AND deleted_at <= '2025-11-28 ...'
-- up to 10.7M rows, single undo log, all pages loaded into buffer pool
```

InnoDB must load every page to be deleted into the buffer pool for the duration of that transaction. This exhausts the pool and generates a massive undo log with no chance to release between rows.

**`_soft_delete_expired_secret_children`** — triggered by `--soft-delete-expired-secrets` — used `synchronize_session='fetch'` on bulk `UPDATE`, causing SQLAlchemy to issue an unbatched `SELECT *` before the update, loading the full result set into application memory. MariaDB itself refuses such queries at scale (`ERROR 1104: The SELECT would examine more than MAX_JOIN_SIZE rows`).

All other `cleanup_*` functions also used `synchronize_session='fetch'` unnecessarily, triggering a `SELECT` of primary keys before every bulk delete.

## Fix

- **`cleanup_softdeletes`**: SELECT IDs in batches of 10 000, DELETE by ID, `COMMIT` after each batch. InnoDB can evict pages and release the undo log between batches. For 10.7M rows this is ~1 070 batches of ~5 MB each against a 10 GB pool — fully manageable.
- **`_soft_delete_expired_secret_children`**: same batched loop with `synchronize_session=False`; adds `~table.deleted` filter so each iteration only picks up rows not yet processed.
- **All bulk DELETE/UPDATE**: drop `synchronize_session='fetch'` in favour of `False` to eliminate the implicit `SELECT` before each bulk operation.
- **`session.expunge_all()` before each batch commit**: prevents `expire_on_commit` from clearing ORM object `__dict__`, so caller-held references remain readable after commit (required to keep existing tests passing).

All 14 existing tests in `barbican/tests/cmd/test_db_cleanup.py` pass.

## Follow-up: `cleanup_parent_with_no_child` is still unbatched

This PR does **not** batch `cleanup_parent_with_no_child`, which runs unconditionally in `cleanup_all` for `(Secret, Order)` and `(Container, Order)`:

```python
# barbican/model/clean.py
delete_count = query.delete(synchronize_session=False)  # single bulk DELETE
```

The query is:
```sql
DELETE FROM secrets
WHERE deleted = 1
  AND deleted_at <= :threshold
  AND id NOT IN (SELECT secret_id FROM orders WHERE ...)
```

With 5.7M rows in `secrets`, if a large proportion are soft-deleted with no Order child, this can still be a single DELETE of hundreds of thousands to millions of rows — same class of problem as `cleanup_softdeletes` before this fix.

**Why not fixed here**: the subquery in `cleanup_parent_with_no_child` is a correlated outer-join, which makes batching non-trivial — naive `LIMIT` on the outer query can interact with the NOT IN subquery in surprising ways. The correct fix is to first materialise the eligible IDs (the inner subquery result) into a batch, then delete. This is a separate, slightly more involved change and should be tracked independently.

**Priority**: medium. On QA-DE-1 with `--min-days 180`, the `secrets` table may have far fewer eligible rows than `secret_store_metadata` did. Monitor the first nanny run after this PR is deployed to determine actual impact.