### PR TITLE
Fix invalid rebaseWhen value in renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,7 +6,7 @@
   "timezone": "Asia/Kolkata",
   "dependencyDashboard": true,
   "semanticCommits": "enabled",
-  "rebaseWhen": "behind-base-branch",
+  "rebaseWhen": "conflicted",
   "prHourlyLimit": 2,
   "prConcurrentLimit": 5,
   "labels": [


### PR DESCRIPTION
"behind-base-branch" is not a valid Renovate value; valid options are "auto", "never", and "conflicted". This caused Renovate to skip the repo entirely.

Change-Id: Id6a0f0e37821dffa89b729e3263fa5910b71bef3