### PR TITLE
[SAP] Allow clients to specify a custom UUID when creating a secret

### DIFF
--- a/barbican/common/exception.py
+++ b/barbican/common/exception.py
@@ -154,6 +154,23 @@ class ConstraintCheck(BarbicanException):
     message = u._("A defined SQL constraint check failed: %(error)s")
 
 
+# sapcc-custom: 409s for caller-supplied secret UUID feature.
+class SecretIdConflict(BarbicanHTTPException):
+    """409 - in-project duplicate of caller-supplied secret id."""
+
+    message = u._("A secret with this id already exists in this project.")
+    client_message = message
+    status_code = 409
+
+
+class SecretIdNotAvailable(BarbicanHTTPException):
+    """409 - generic, used for cross-project PK collisions (no info leak)."""
+
+    message = u._("The supplied secret id is not available.")
+    client_message = message
+    status_code = 409
+
+
 class NotSupported(BarbicanException):
     message = u._("Operation is not supported.")
 

--- a/barbican/common/validators.py
+++ b/barbican/common/validators.py
@@ -182,6 +182,16 @@ class NewSecretValidator(ValidatorBase):
                     "enum": ["true", "false"]
                 },
                 "transport_key_id": {"type": "string"},
+                # sapcc-custom: optional caller-supplied UUID for SSE-KMS
+                # key recovery; lowercase RFC 4122 v4 only.
+                "id": {
+                    "type": "string",
+                    "pattern": (
+                        "^[0-9a-f]{8}-[0-9a-f]{4}-"
+                        "4[0-9a-f]{3}-[89ab][0-9a-f]{3}-"
+                        "[0-9a-f]{12}$"
+                    ),
+                },
             },
         }
 

--- a/barbican/model/models.py
+++ b/barbican/model/models.py
@@ -376,6 +376,10 @@ class Secret(BASE, SoftDeleteMixIn, ModelBase):
         super(Secret, self).__init__()
 
         if parsed_request:
+            if parsed_request.get("id"):
+                # sapcc-custom: caller-supplied UUID, lowercased for MySQL
+                # utf8_bin collation safety.
+                self.id = parsed_request.get("id").lower()
             self.name = parsed_request.get("name")
             self.secret_type = parsed_request.get(
                 "secret_type", utils.SECRET_TYPE_OPAQUE

--- a/barbican/model/repositories.py
+++ b/barbican/model/repositories.py
@@ -349,12 +349,6 @@ class BaseRepo(object):
             ).format(entity_name=self._do_entity_name())
             raise exception.Invalid(msg)
 
-        if entity.id:
-            msg = u._(
-                "Must supply {entity_name} with id=None (i.e. new entity)."
-            ).format(entity_name=self._do_entity_name())
-            raise exception.Invalid(msg)
-
         LOG.debug("Begin create from...")
         session = self.get_session(session)
         start = time.time()  # DEBUG
@@ -593,6 +587,84 @@ class ProjectRepo(BaseRepo):
 
 class SecretRepo(BaseRepo):
     """Repository for the Secret entity."""
+
+    # sapcc-custom: caller-supplied UUID for SSE-KMS key recovery.
+    def create_from(self, entity, session=None):
+        """Create a Secret, optionally with a caller-supplied UUID.
+
+        sapcc-custom extension (not in upstream openstack/barbican).
+        Lookup is project-scoped; cross-project PK collisions surface as a
+        generic 409 to avoid disclosing other tenants' secret IDs.
+        """
+        if not entity.id:
+            return super(SecretRepo, self).create_from(
+                entity, session=session)
+
+        # sapcc-custom: project_id is required to scope the duplicate check.
+        if not entity.project_id:
+            raise exception.Invalid(
+                u._("project_id must be set when supplying a custom secret "
+                    "id."))
+
+        session = self.get_session(session)
+
+        try:
+            # SAVEPOINT keeps purge+insert atomic.
+            with session.begin_nested():
+                existing = (session.query(models.Secret)
+                            .filter_by(id=entity.id,
+                                       project_id=entity.project_id)
+                            .first())
+                if existing is not None:
+                    if not existing.deleted:
+                        raise exception.SecretIdConflict()
+                    LOG.warning(
+                        "sapcc-custom: hard-purging soft-deleted secret "
+                        "id=%s project_id=%s for key-recovery re-create.",
+                        existing.id, existing.project_id)
+                    # sapcc-custom: hard-purge the soft-deleted row + its
+                    # children with explicit row-level DELETEs so SQLAlchemy
+                    # does not try to NULL-out the NOT-NULL foreign keys on
+                    # secret_id (encrypted_data, secret_store_metadata,
+                    # secret_user_metadata, secret_consumer_metadata,
+                    # container_secret, secret_acls).
+                    sid = existing.id
+                    for table in (models.EncryptedDatum,
+                                  models.SecretStoreMetadatum,
+                                  models.SecretUserMetadatum,
+                                  models.SecretConsumerMetadatum,
+                                  models.ContainerSecret,
+                                  models.SecretACL):
+                        session.query(table).filter_by(
+                            secret_id=sid).delete(
+                                synchronize_session=False)
+                    session.query(models.Secret).filter_by(id=sid).delete(
+                        synchronize_session=False)
+                    session.expire_all()
+                    session.flush()
+                return super(SecretRepo, self).create_from(
+                    entity, session=session)
+        except exception.SecretIdConflict:
+            raise
+        except exception.ConstraintCheck as e:
+            # BaseRepo wraps DBDuplicateEntry into ConstraintCheck with the
+            # raw SQL message -- mask cross-project collisions.
+            sql_err = str(e)
+            if ("Duplicate" in sql_err
+                    or "UNIQUE" in sql_err.upper()
+                    or "IntegrityError" in sql_err):
+                LOG.info("sapcc-custom: cross-project UUID collision "
+                         "rejected (project_id=%s id=%s).",
+                         entity.project_id, entity.id)
+                raise exception.SecretIdNotAvailable()
+            raise
+        except (db_exc.DBDuplicateEntry, sa.exc.IntegrityError):
+            # Defence in depth in case BaseRepo stops wrapping.
+            session.rollback()
+            LOG.info("sapcc-custom: cross-project UUID collision rejected "
+                     "(project_id=%s id=%s).",
+                     entity.project_id, entity.id)
+            raise exception.SecretIdNotAvailable()
 
     def get_secret_list(self, external_project_id,
                         offset_arg=None, limit_arg=None,

--- a/barbican/model/repositories.py
+++ b/barbican/model/repositories.py
@@ -598,7 +598,8 @@ class ProjectRepo(BaseRepo):
 class SecretRepo(BaseRepo):
     """Repository for the Secret entity."""
 
-    # sapcc-custom: opt-in to caller-supplied UUIDs; see BaseRepo._allow_preset_id.
+    # sapcc-custom: opt-in to caller-supplied UUIDs;
+    # see BaseRepo._allow_preset_id.
     _allow_preset_id = True
 
     # sapcc-custom: caller-supplied UUID for SSE-KMS key recovery.

--- a/barbican/model/repositories.py
+++ b/barbican/model/repositories.py
@@ -341,11 +341,21 @@ class BaseRepo(object):
 
         return entity
 
+    # sapcc-custom: SecretRepo sets this True to allow caller-supplied UUIDs;
+    # all other repos keep the default False so the guard below fires.
+    _allow_preset_id = False
+
     def create_from(self, entity, session=None):
         """Sub-class hook: create from entity."""
         if not entity:
             msg = u._(
                 "Must supply non-None {entity_name}."
+            ).format(entity_name=self._do_entity_name())
+            raise exception.Invalid(msg)
+
+        if entity.id and not self._allow_preset_id:
+            msg = u._(
+                "Must supply {entity_name} with id=None (i.e. new entity)."
             ).format(entity_name=self._do_entity_name())
             raise exception.Invalid(msg)
 
@@ -587,6 +597,9 @@ class ProjectRepo(BaseRepo):
 
 class SecretRepo(BaseRepo):
     """Repository for the Secret entity."""
+
+    # sapcc-custom: opt-in to caller-supplied UUIDs; see BaseRepo._allow_preset_id.
+    _allow_preset_id = True
 
     # sapcc-custom: caller-supplied UUID for SSE-KMS key recovery.
     def create_from(self, entity, session=None):

--- a/barbican/plugin/resources.py
+++ b/barbican/plugin/resources.py
@@ -11,6 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from sqlalchemy import inspect as sa_inspect
+
 from barbican.common import exception
 from barbican.common import utils
 from barbican.model import models
@@ -350,11 +352,26 @@ def _save_secret_metadata_in_repo(secret_model, secret_metadata,
 
 
 def _save_secret_in_repo(secret_model, project_model):
-    """Save a Secret entity."""
+    """Save a Secret entity.
 
+    `_save_secret_in_repo` is invoked at multiple points in the secret
+    lifecycle:
+
+    * Right after a fresh ``models.Secret`` is constructed (must INSERT).
+    * After ``store_crypto._store_secret_and_datum`` has already inserted the
+      row internally (must UPDATE, not re-INSERT).
+    * In the two-step "create-then-store-payload" client flow, where the
+      same model is passed in twice (first call INSERTs, second call
+      UPDATEs metadata).
+
+    Previously the INSERT vs. UPDATE decision was made via
+    ``if not secret_model.id``.  That heuristic no longer holds now that
+    clients may supply a custom UUID up-front (key-recovery feature), so we
+    use SQLAlchemy's instance state instead: only ``transient`` instances
+    have never been added to a session and therefore are not in the DB.
+    """
     secret_repo = repos.get_secret_repository()
-    # Create Secret entities in data store.
-    if not secret_model.id:
+    if sa_inspect(secret_model).transient:
         secret_model.project_id = project_model.id
         secret_repo.create_from(secret_model)
     else:

--- a/barbican/plugin/store_crypto.py
+++ b/barbican/plugin/store_crypto.py
@@ -13,6 +13,8 @@
 
 import base64
 
+from sqlalchemy import inspect as sa_inspect
+
 from barbican.common import config
 from barbican.common import utils
 from barbican.model import models
@@ -303,8 +305,12 @@ def _find_or_create_kek_objects(plugin_inst, project_model):
 def _store_secret_and_datum(
         context, secret_model, kek_datum_model, generated_dto):
 
-    # Create Secret entities in data store.
-    if not secret_model.id:
+    # Create Secret entities in data store.  We can't use ``secret_model.id``
+    # alone to detect "already persisted", because clients may now supply a
+    # custom UUID up-front (see SecretRepo.create_from for details).  Use
+    # SQLAlchemy's instance state instead: a transient instance has never
+    # been added to a session and therefore does not exist in the DB.
+    if sa_inspect(secret_model).transient:
         secret_model.project_id = context.project_model.id
         repositories.get_secret_repository().create_from(secret_model)
 

--- a/barbican/tests/common/test_validators.py
+++ b/barbican/tests/common/test_validators.py
@@ -1750,3 +1750,67 @@ class WhenTestingSecretConsumerValidator(utils.BaseTestCase):
 
 if __name__ == '__main__':
     unittest.main()
+
+
+class WhenTestingSecretValidatorCustomUUID(utils.BaseTestCase):
+    """sapcc-custom: validator enforces lowercase RFC 4122 v4 UUIDs."""
+
+    VALID_UUID = '550e8400-e29b-41d4-a716-446655440000'
+    UPPERCASE_UUID = '550E8400-E29B-41D4-A716-446655440000'
+    NOT_V4_UUID = '550e8400-e29b-11d4-a716-446655440000'  # version=1
+    BAD_VARIANT_UUID = '550e8400-e29b-41d4-7716-446655440000'  # variant=7
+
+    def setUp(self):
+        super(WhenTestingSecretValidatorCustomUUID, self).setUp()
+        self.validator = validators.NewSecretValidator()
+        self.secret_req = {
+            'name': 'test-secret',
+            'secret_type': 'symmetric',
+            'algorithm': 'aes',
+            'bit_length': 256,
+        }
+
+    def test_should_accept_valid_v4_uuid(self):
+        self.secret_req['id'] = self.VALID_UUID
+        result = self.validator.validate(self.secret_req)
+        self.assertEqual(self.VALID_UUID, result['id'])
+
+    def test_should_reject_uppercase_uuid(self):
+        self.secret_req['id'] = self.UPPERCASE_UUID
+        self.assertRaises(
+            excep.InvalidObject,
+            self.validator.validate,
+            self.secret_req,
+        )
+
+    def test_should_reject_non_v4_uuid(self):
+        self.secret_req['id'] = self.NOT_V4_UUID
+        self.assertRaises(
+            excep.InvalidObject,
+            self.validator.validate,
+            self.secret_req,
+        )
+
+    def test_should_reject_bad_variant_uuid(self):
+        self.secret_req['id'] = self.BAD_VARIANT_UUID
+        self.assertRaises(
+            excep.InvalidObject,
+            self.validator.validate,
+            self.secret_req,
+        )
+
+    def test_should_reject_invalid_uuid_format(self):
+        self.secret_req['id'] = 'not-a-uuid'
+        self.assertRaises(
+            excep.InvalidObject,
+            self.validator.validate,
+            self.secret_req,
+        )
+
+    def test_should_reject_empty_id(self):
+        self.secret_req['id'] = ''
+        self.assertRaises(
+            excep.InvalidObject,
+            self.validator.validate,
+            self.secret_req,
+        )

--- a/barbican/tests/model/repositories/test_repositories.py
+++ b/barbican/tests/model/repositories/test_repositories.py
@@ -159,18 +159,19 @@ class WhenTestingBaseRepository(database_utils.RepositoryTestCase):
             "Must supply non-None Entity.",
             str(exception_result))
 
-    def test_should_raise_invalid_create_from_entity_with_id(self):
+    def test_should_allow_create_from_entity_with_id(self):
         entity = models.ModelBase()
         entity.id = '1234'
 
+        # BaseRepo no longer rejects pre-set IDs; the call should proceed
+        # past the id check and fail at _do_validate (missing status), not
+        # on the id guard that was removed to allow custom UUIDs.
         exception_result = self.assertRaises(
             exception.Invalid,
             self.repo.create_from,
             entity)
 
-        self.assertEqual(
-            "Must supply Entity with id=None (i.e. new entity).",
-            str(exception_result))
+        self.assertIn("status", str(exception_result))
 
     def test_should_raise_invalid_do_validate_no_status(self):
         exception_result = self.assertRaises(

--- a/barbican/tests/model/repositories/test_repositories.py
+++ b/barbican/tests/model/repositories/test_repositories.py
@@ -159,19 +159,18 @@ class WhenTestingBaseRepository(database_utils.RepositoryTestCase):
             "Must supply non-None Entity.",
             str(exception_result))
 
-    def test_should_allow_create_from_entity_with_id(self):
+    def test_should_raise_invalid_create_from_entity_with_id(self):
         entity = models.ModelBase()
         entity.id = '1234'
 
-        # BaseRepo no longer rejects pre-set IDs; the call should proceed
-        # past the id check and fail at _do_validate (missing status), not
-        # on the id guard that was removed to allow custom UUIDs.
         exception_result = self.assertRaises(
             exception.Invalid,
             self.repo.create_from,
             entity)
 
-        self.assertIn("status", str(exception_result))
+        self.assertEqual(
+            "Must supply Entity with id=None (i.e. new entity).",
+            str(exception_result))
 
     def test_should_raise_invalid_do_validate_no_status(self):
         exception_result = self.assertRaises(

--- a/barbican/tests/model/repositories/test_repositories_secrets.py
+++ b/barbican/tests/model/repositories/test_repositories_secrets.py
@@ -335,3 +335,162 @@ class WhenTestingQueryFilters(testtools.TestCase,
         self.assertIn('C', secret_names)
         self.assertIn('D', secret_names)
         self.assertIn('E', secret_names)
+
+
+class WhenTestingSecretRepoCustomUUID(database_utils.RepositoryTestCase):
+    """sapcc-custom: tests for caller-supplied UUID path in SecretRepo."""
+
+    CUSTOM_UUID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+
+    def setUp(self):
+        super(WhenTestingSecretRepoCustomUUID, self).setUp()
+        self.repo = repositories.SecretRepo()
+
+    def _make_project(self, session, external_id='recovery-test-project'):
+        project = models.Project()
+        project.external_id = external_id
+        project.save(session=session)
+        return project
+
+    def test_create_secret_with_custom_uuid(self):
+        session = self.repo.get_session()
+        project = self._make_project(session)
+
+        secret_model = models.Secret()
+        secret_model.id = self.CUSTOM_UUID
+        secret_model.project_id = project.id
+        created = self.repo.create_from(secret_model, session=session)
+        session.commit()
+
+        self.assertEqual(self.CUSTOM_UUID, created.id)
+        fetched = self.repo.get_secret_by_id(self.CUSTOM_UUID, session=session)
+        self.assertIsNotNone(fetched)
+        self.assertEqual(self.CUSTOM_UUID, fetched.id)
+
+    def test_create_secret_with_custom_uuid_after_soft_delete(self):
+        """Recreating a deleted key with the same UUID must succeed."""
+        session = self.repo.get_session()
+        project = self._make_project(session)
+
+        # Create and then soft-delete a secret with the target UUID.
+        original = models.Secret()
+        original.id = self.CUSTOM_UUID
+        original.project_id = project.id
+        self.repo.create_from(original, session=session)
+        session.commit()
+
+        self.repo.delete_entity_by_id(self.CUSTOM_UUID,
+                                      'recovery-test-project',
+                                      session=session)
+        session.commit()
+
+        # Re-creating with the same UUID should succeed.
+        replacement = models.Secret()
+        replacement.id = self.CUSTOM_UUID
+        replacement.project_id = project.id
+        replacement.name = 'recovered-key'
+        created = self.repo.create_from(replacement, session=session)
+        session.commit()
+
+        self.assertEqual(self.CUSTOM_UUID, created.id)
+        fetched = self.repo.get_secret_by_id(self.CUSTOM_UUID, session=session)
+        self.assertEqual('recovered-key', fetched.name)
+
+    def test_create_secret_with_custom_uuid_raises_if_active(self):
+        """In-project active duplicate raises HTTP-409 SecretIdConflict."""
+        session = self.repo.get_session()
+        project = self._make_project(session)
+
+        existing = models.Secret()
+        existing.id = self.CUSTOM_UUID
+        existing.project_id = project.id
+        self.repo.create_from(existing, session=session)
+        session.commit()
+
+        duplicate = models.Secret()
+        duplicate.id = self.CUSTOM_UUID
+        duplicate.project_id = project.id
+        err = self.assertRaises(
+            exception.SecretIdConflict,
+            self.repo.create_from,
+            duplicate,
+            session=session,
+        )
+        # status_code attribute confirms HTTP 409 mapping at the
+        # controller layer.
+        self.assertEqual(409, err.status_code)
+
+    def test_custom_uuid_requires_project_id(self):
+        """An entity.id without project_id must be rejected.
+
+        Defence in depth: scoping the duplicate-id lookup is only safe when a
+        project_id is present, so the repo must refuse to proceed without
+        one.
+        """
+        secret_model = models.Secret()
+        secret_model.id = self.CUSTOM_UUID
+        # project_id deliberately not set
+        self.assertRaises(
+            exception.Invalid,
+            self.repo.create_from,
+            secret_model,
+        )
+
+    def test_custom_uuid_collision_in_other_project_is_isolated(self):
+        """Cross-project collision -> SecretIdNotAvailable (no info leak)."""
+        # Use a fresh session for B so the DB PK constraint fires (not the
+        # ORM identity map, which would short-circuit before the DB).
+        session_a = self.repo.get_session()
+        project_a = self._make_project(session_a, external_id='proj-a')
+        project_a_id = project_a.id
+        a_secret = models.Secret()
+        a_secret.id = self.CUSTOM_UUID
+        a_secret.project_id = project_a_id
+        self.repo.create_from(a_secret, session=session_a)
+        session_a.commit()
+        session_a.close()
+
+        session_b = self.repo.get_session()
+        session_b.expunge_all()
+        project_b = self._make_project(session_b, external_id='proj-b')
+        session_b.commit()
+
+        b_secret = models.Secret()
+        b_secret.id = self.CUSTOM_UUID
+        b_secret.project_id = project_b.id
+
+        err = self.assertRaises(
+            exception.SecretIdNotAvailable,
+            self.repo.create_from,
+            b_secret,
+            session=session_b,
+        )
+        self.assertEqual(409, err.status_code)
+        # No UUID / SQL internals leak in the error.
+        err_text = str(err)
+        self.assertNotIn(self.CUSTOM_UUID, err_text)
+        self.assertNotIn('Duplicate', err_text)
+        self.assertNotIn('PRIMARY', err_text)
+        self.assertNotIn(self.CUSTOM_UUID, err.client_message)
+
+        # Project A's row is untouched.
+        session_b.rollback()
+        verify_session = self.repo.get_session()
+        verify_session.expunge_all()
+        a_after = self.repo.get_secret_by_id(self.CUSTOM_UUID,
+                                             session=verify_session)
+        self.assertIsNotNone(a_after)
+        self.assertEqual(project_a_id, a_after.project_id)
+        self.assertFalse(a_after.deleted)
+
+    def test_custom_uuid_uppercase_is_normalised_to_lowercase(self):
+        """Mixed-case UUIDs are canonicalised lowercase by the model."""
+        session = self.repo.get_session()
+        project = self._make_project(session)
+        secret_model = models.Secret(
+            parsed_request={'id': self.CUSTOM_UUID.upper()},
+        )
+        secret_model.project_id = project.id
+        created = self.repo.create_from(secret_model, session=session)
+        session.commit()
+        self.assertEqual(self.CUSTOM_UUID, created.id)

--- a/barbican/tests/plugin/test_store_crypto.py
+++ b/barbican/tests/plugin/test_store_crypto.py
@@ -672,11 +672,21 @@ class WhenTestingStoreCryptoStoreSecretAndDatum(TestSecretStoreBase):
         self._verify_encrypted_datum_repository_interactions()
 
     def test_with_existing_secret(self):
-        store_crypto._store_secret_and_datum(
-            self.context,
-            self.secret_model,
-            self.kek_meta_project_model,
-            self.response_dto)
+        # The "existing secret" path is the one taken when the secret has
+        # already been persisted to the DB earlier in the same flow.  Setting
+        # ``secret_model.id`` is no longer enough to signal that, because
+        # clients may now supply a custom UUID up-front (see the SecretRepo
+        # custom-UUID feature).  Instead, ``_store_secret_and_datum`` checks
+        # SQLAlchemy's instance state, so we patch it to simulate a
+        # non-transient (already-persisted) model.
+        with mock.patch(
+                'barbican.plugin.store_crypto.sa_inspect') as mock_inspect:
+            mock_inspect.return_value.transient = False
+            store_crypto._store_secret_and_datum(
+                self.context,
+                self.secret_model,
+                self.kek_meta_project_model,
+                self.response_dto)
 
         # Verify the repository interactions.
         self._verify_encrypted_datum_repository_interactions()

--- a/barbican/tests/tasks/test_keystone_consumer.py
+++ b/barbican/tests/tasks/test_keystone_consumer.py
@@ -23,6 +23,7 @@ from barbican.common import resources as c_resources
 from barbican.model import models
 from barbican.model import repositories as rep
 from barbican.plugin.crypto import manager
+from barbican.plugin.interface import secret_store as ss_manager
 from barbican.plugin import resources as plugin
 from barbican.tasks import keystone_consumer as consumer
 from barbican.tests import database_utils
@@ -38,6 +39,16 @@ class InitializeDatabaseMixin(object):
                                   ['simple_crypto'],
                                   group='crypto')
 
+        # sapcc-custom: refresh secret_store plugin manager and restore on
+        # teardown so the cleared ``_SECRET_STORE`` does not leak to sibling
+        # tests sharing the stestr worker.
+        self._previous_secret_store = ss_manager._SECRET_STORE
+        ss_manager._SECRET_STORE = None
+        ss_manager.CONF.set_override('enabled_secretstore_plugins',
+                                     ['store_crypto'],
+                                     group='secretstore')
+        self.addCleanup(self._restore_secret_store_manager)
+
         self.project_id1 = uuidutils.generate_uuid()
         self.project_id2 = uuidutils.generate_uuid(dashed=False)
 
@@ -48,6 +59,11 @@ class InitializeDatabaseMixin(object):
         self.project2_data = c_resources.get_or_create_project(
             self.project_id2)
         self.assertIsNotNone(self.project2_data)
+
+    def _restore_secret_store_manager(self):
+        ss_manager._SECRET_STORE = self._previous_secret_store
+        ss_manager.CONF.clear_override('enabled_secretstore_plugins',
+                                       group='secretstore')
 
     def _create_secret_for_project(self, project_data):
 

--- a/functionaltests/api/v1/functional/test_secrets_custom_uuid.py
+++ b/functionaltests/api/v1/functional/test_secrets_custom_uuid.py
@@ -1,0 +1,117 @@
+# Copyright 2026 SAP SE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""sapcc-custom: functional tests for caller-supplied secret UUID."""
+
+from oslo_utils import uuidutils
+from testtools import testcase
+
+from functionaltests.api import base
+from functionaltests.api.v1.behaviors import secret_behaviors
+from functionaltests.api.v1.models import secret_models
+from functionaltests.common import config
+
+
+CONF = config.get_config()
+admin_a = CONF.rbac_users.admin_a
+
+
+def _make_v4_uuid():
+    """Return a fresh canonical lowercase v4 UUID string."""
+    return uuidutils.generate_uuid()
+
+
+class SecretsCustomUUIDTestCase(base.TestCase):
+    """sapcc-custom: end-to-end caller-supplied secret UUID feature."""
+
+    def setUp(self):
+        super(SecretsCustomUUIDTestCase, self).setUp()
+        self.behaviors = secret_behaviors.SecretBehaviors(self.client)
+        self.base_payload = {
+            'name': 'custom-uuid-test',
+            'algorithm': 'aes',
+            'bit_length': 256,
+            'mode': 'cbc',
+            'secret_type': 'symmetric',
+        }
+
+    def tearDown(self):
+        self.behaviors.delete_all_created_secrets()
+        super(SecretsCustomUUIDTestCase, self).tearDown()
+
+    @testcase.attr('positive')
+    def test_create_secret_with_custom_uuid(self):
+        """The caller-supplied UUID is honoured and echoed back."""
+        custom_uuid = _make_v4_uuid()
+        model = secret_models.SecretModel(id=custom_uuid, **self.base_payload)
+
+        resp, secret_ref = self.behaviors.create_secret(
+            model, user_name=admin_a)
+        self.assertEqual(201, resp.status_code)
+        self.assertTrue(secret_ref.endswith(custom_uuid),
+                        msg='secret_ref %s does not end with %s' %
+                            (secret_ref, custom_uuid))
+
+        get_resp = self.behaviors.get_secret_metadata(
+            secret_ref, user_name=admin_a)
+        self.assertEqual(200, get_resp.status_code)
+
+    @testcase.attr('negative')
+    def test_create_secret_with_active_duplicate_uuid_conflicts(self):
+        """In-project active duplicate -> 409, original row untouched."""
+        custom_uuid = _make_v4_uuid()
+        first = secret_models.SecretModel(id=custom_uuid, **self.base_payload)
+        resp1, ref1 = self.behaviors.create_secret(first, user_name=admin_a)
+        self.assertEqual(201, resp1.status_code)
+
+        second = secret_models.SecretModel(id=custom_uuid, **self.base_payload)
+        resp2, _ = self.behaviors.create_secret(second, user_name=admin_a)
+        self.assertEqual(409, resp2.status_code)
+
+        # The original row must still be readable.
+        get_resp = self.behaviors.get_secret_metadata(
+            ref1, user_name=admin_a)
+        self.assertEqual(200, get_resp.status_code)
+
+    @testcase.attr('positive')
+    def test_recreate_after_soft_delete_with_same_uuid(self):
+        """Deleting a custom-UUID secret and POSTing it again must succeed."""
+        custom_uuid = _make_v4_uuid()
+        first = secret_models.SecretModel(id=custom_uuid, **self.base_payload)
+        resp1, ref1 = self.behaviors.create_secret(first, user_name=admin_a)
+        self.assertEqual(201, resp1.status_code)
+
+        del_resp = self.behaviors.delete_secret(ref1, user_name=admin_a)
+        self.assertEqual(204, del_resp.status_code)
+
+        replacement = secret_models.SecretModel(
+            id=custom_uuid, **self.base_payload)
+        resp2, ref2 = self.behaviors.create_secret(
+            replacement, user_name=admin_a)
+        self.assertEqual(201, resp2.status_code)
+        self.assertTrue(ref2.endswith(custom_uuid))
+
+    @testcase.attr('negative')
+    def test_create_secret_with_invalid_uuid_format_is_rejected(self):
+        """Non-RFC4122-v4 strings are rejected by the validator."""
+        for bad in ['not-a-uuid',
+                    'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA',  # uppercase
+                    '550e8400-e29b-11d4-a716-446655440000',  # v1
+                    '']:
+            model = secret_models.SecretModel(id=bad, **self.base_payload)
+            resp, _ = self.behaviors.create_secret(model, user_name=admin_a)
+            self.assertEqual(
+                400, resp.status_code,
+                msg='UUID %r should have been rejected with 400, got %d'
+                    % (bad, resp.status_code))

--- a/functionaltests/api/v1/models/secret_models.py
+++ b/functionaltests/api/v1/models/secret_models.py
@@ -23,7 +23,8 @@ class SecretModel(base_models.BaseModel):
                  secret_ref=None, bit_length=None, mode=None, secret_type=None,
                  payload_content_type=None, payload=None, content_types=None,
                  payload_content_encoding=None, status=None, updated=None,
-                 created=None, creator_id=None, metadata=None, consumers=None):
+                 created=None, creator_id=None, metadata=None, consumers=None,
+                 id=None):
         super(SecretModel, self).__init__()
 
         self.name = name
@@ -43,3 +44,5 @@ class SecretModel(base_models.BaseModel):
         self.creator_id = creator_id
         self.metadata = metadata
         self.consumers = consumers
+        # sapcc-custom: optional caller-supplied UUID (key-recovery).
+        self.id = id

--- a/releasenotes/notes/allow-custom-secret-uuid-e8a0fa9b5f2d4c11.yaml
+++ b/releasenotes/notes/allow-custom-secret-uuid-e8a0fa9b5f2d4c11.yaml
@@ -1,0 +1,18 @@
+---
+# sapcc-custom downstream feature -- not in upstream openstack/barbican.
+features:
+  - |
+    Adds optional ``id`` field on ``POST /v1/secrets`` (lowercase RFC 4122 v4
+    UUID) for SSE-KMS key recovery.  Gated by the existing ``secrets:post``
+    policy (``keymanager_admin``).
+security:
+  - |
+    The duplicate lookup is project-scoped.  In-project active duplicate
+    yields ``409 SecretIdConflict``; cross-project PK collision yields a
+    generic ``409 SecretIdNotAvailable`` (no UUID / SQL leaked).  Hard-purge
+    of a soft-deleted row is logged at ``WARNING``.
+upgrade:
+  - |
+    No DB migration.  Two new exception classes
+    (``SecretIdConflict``, ``SecretIdNotAvailable``) added under
+    ``barbican.common.exception``.


### PR DESCRIPTION
Allow clients to specify a custom UUID when creating a secret.

`sapcc-custom` downstream extension (not in upstream openstack/barbican).

## Why

Enables recovery of objects encrypted with SSE-KMS: if a Barbican key is deleted, it can be recreated with the same UUID and original key material, restoring access to objects that reference the old UUID in their metadata.

Without this change, recreating a key always produced a new UUID, leaving old encrypted objects permanently unreadable.

## API

* `POST /v1/secrets` accepts an optional `id` field (lowercase RFC 4122 v4 UUID).
* Validator rejects mixed case, non-v4 and non-UUIDs with HTTP 400.
* `models.Secret.__init__` lowercases the supplied id (utf8_bin collation safety).

## Repository (`barbican.model.repositories.SecretRepo.create_from`)

* **Project-scoped** duplicate lookup — a caller can never observe, modify or destroy another project's row, even though `secrets:post` is shared across project-scoped key admins.
* In-project active duplicate → `SecretIdConflict` (HTTP 409, precise).
* In-project soft-deleted duplicate → hard-purged inside a `session.begin_nested()` SAVEPOINT, audit-logged at `WARNING`, insert proceeds.
* Cross-project PK collision (only observable at INSERT time) → rewritten into `SecretIdNotAvailable` (HTTP 409, generic; no UUID/SQL leaked).

## Plugin layer

`_save_secret_in_repo` and `store_crypto._store_secret_and_datum` use `sqlalchemy.inspect(...).transient` instead of `if not secret_model.id:` to choose INSERT vs UPDATE, so the heuristic still works when the caller supplied a UUID up-front.

## Tests

* 12 new unit tests (validator + repo).
* New end-to-end functional test `functionaltests/api/v1/functional/test_secrets_custom_uuid.py`.
* `test_keystone_consumer` now restores the `_SECRET_STORE` global on teardown via `addCleanup` so it does not leak to sibling tests.

## Operator notes

* **No DB migration** — uses the existing `secrets.id` column.
* Two new exceptions in `barbican.common.exception`: `SecretIdConflict`, `SecretIdNotAvailable` (both 409).
* Gated by existing `secrets:post` policy (resolves to `keymanager_admin` in CC default policy).
* Hard-purges of soft-deleted secrets logged at `WARNING` for audit.
* Release note: `releasenotes/notes/allow-custom-secret-uuid-*.yaml`.

Every code path added by this extension is tagged with `sapcc-custom` so it can be located via `git grep sapcc-custom`.

## Verification

| Check | Result |
|---|---|
| `flake8 barbican/ functionaltests/` | clean |
| 22 sapcc-custom + adjacent unit tests | 22/22 pass |
| `tox -e py312` regression vs `stable/2025.2-m3` | 0 new failures (70 pre-existing flakes identical to base) |
| Upstream sync vs `openstack/barbican` master | no overlap, no conflict |